### PR TITLE
Trim leading/trailing whitespace and newlines when sending a message

### DIFF
--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -517,7 +517,11 @@ public struct ChatFeature {
 
       case .composerSubmitted:
         guard state.canSend, let sessionID = state.liveSessionID else { return .none }
-        let text = state.composerText
+        // Trim stray leading/trailing whitespace/newlines (soft-wrap, dictation, accidental
+        // returns) before submitting; interior formatting is preserved (#31). `canSend`
+        // already rejects whitespace-only input with no attachments, so `text` can only be
+        // empty here when attachments carry the send.
+        let text = state.composerText.trimmingCharacters(in: .whitespacesAndNewlines)
 
         // With attachments we must upload bytes first (iOS shares no FS with the agent),
         // then submit — so we keep the composer/attachments until success and only echo the

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -480,6 +480,57 @@ struct ChatReductionTests {
     }
   }
 
+  // Leading/trailing whitespace and newlines are trimmed before submit (#31); interior
+  // formatting is preserved. The trimmed text is both what's echoed in the user row and
+  // what goes out on the wire.
+  @Test func composerSubmitTrimsLeadingTrailingWhitespaceAndNewlines() async {
+    let sentText = LockIsolated<String?>(nil)
+    var initial = ChatFeature.State(connection: conn, status: .ready)
+    initial.liveSessionID = "live"
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(.init(timeIntervalSince1970: 0))
+      $0.hermesGateway.send = { @Sendable _, params in
+        sentText.setValue(params["text"]?.stringValue)
+        return .object(["status": .string("streaming")])
+      }
+    }
+
+    let raw = "  \n\nline one\n\n  indented line two  \n \n"
+    let trimmed = "line one\n\n  indented line two"
+    await store.send(\.binding.composerText, raw) { $0.composerText = raw }
+    await store.send(.composerSubmitted) {
+      $0.transcript = [ChatRow(id: uuid(0), kind: .message(role: .user, text: trimmed, isComplete: true))]
+      $0.composerText = ""
+      $0.isSending = true
+    }
+    await store.finish()
+    #expect(sentText.value == trimmed)
+  }
+
+  // Whitespace-only input never submits: canSend is false, so composerSubmitted is a no-op
+  // (nothing sent, composer untouched).
+  @Test func composerSubmitIgnoresWhitespaceOnlyInput() async {
+    let didSend = LockIsolated(false)
+    var initial = ChatFeature.State(connection: conn, status: .ready)
+    initial.liveSessionID = "live"
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.hermesGateway.send = { @Sendable _, _ in
+        didSend.setValue(true)
+        return .object(["status": .string("streaming")])
+      }
+    }
+
+    await store.send(\.binding.composerText, "  \n\n \t ") { $0.composerText = "  \n\n \t " }
+    #expect(store.state.canSend == false)
+    await store.send(.composerSubmitted)
+    #expect(didSend.value == false)
+  }
+
   // MARK: Bootstrap (create on first ready)
 
   @Test func createsSessionOnFirstReady() async {


### PR DESCRIPTION
Closes #31

Trims stray leading/trailing whitespace and newlines from the composer text at the single point where `.composerSubmitted` captures it, so both the plain-text and attachments submit paths use the trimmed text — for the echoed user row and the `prompt.submit` wire payload. Interior whitespace/newlines are preserved. `canSend` already rejected whitespace-only input with no attachments; with attachments, whitespace-only text now correctly falls out to an attachment-only send instead of sending the raw whitespace.

## Tests
- `composerSubmitTrimsLeadingTrailingWhitespaceAndNewlines` — leading/trailing spaces and newlines stripped, interior blank line and indentation preserved, asserted on both the transcript row and the wire text
- `composerSubmitIgnoresWhitespaceOnlyInput` — whitespace-only input: `canSend` is false, submit is a no-op, nothing sent

Full HermesKit suite passes (653 tests).