### PR TITLE
Auto-validate the pre-filled server URL when onboarding appears

### DIFF
--- a/HermesKit/Package.resolved
+++ b/HermesKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3aa4c02f857f3e4800d287fc29e379e7627be20b98a151c9164b14b6a74fd55f",
+  "originHash" : "ff9e472bc485688cf5f148d339b1d8b0bec9bdce20f84c4c0e05539db9c75fcb",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "c525e53936c878c102421eee241d82711eb38104",
         "version" : "2.8.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "1bc16f430d8410e7f087d4c787767b26fd32fe30",
+        "version" : "1.19.3"
       }
     },
     {

--- a/HermesKit/Sources/HermesKit/Features/ConnectionFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ConnectionFeature.swift
@@ -105,6 +105,8 @@ public struct ConnectionFeature {
 
   public enum Action: BindableAction {
     case binding(BindingAction<State>)
+    /// The screen appeared — auto-check a pre-filled URL (#38).
+    case onAppear
     /// Reachability check (debounced after typing, or fired on submit/focus-loss).
     case checkServer
     /// The URL field was submitted or lost focus — check immediately.
@@ -151,6 +153,17 @@ public struct ConnectionFeature {
 
       case .binding:
         return .none
+
+      case .onAppear:
+        // A pre-filled URL (launch auto-connect fallback / logout) is validated immediately
+        // so the sign-in step unlocks without the user having to focus the field first (#38).
+        // Reuses the field-driven check path — no duplicated validation logic. Only fires
+        // from a pristine `.idle` so a re-appear (e.g. popping back from the secure-connect
+        // details screen) never clobbers a completed or in-flight check.
+        guard state.status == .idle,
+              !state.serverURL.trimmingCharacters(in: .whitespaces).isEmpty
+        else { return .none }
+        return .send(.checkServer)
 
       case .serverFieldCommitted:
         // Submit / focus-loss → check now, pre-empting the debounce.

--- a/HermesKit/Tests/HermesKitTests/ConnectionFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ConnectionFeatureTests.swift
@@ -92,6 +92,51 @@ struct ConnectionFeatureTests {
     await store.receive(\.checkServer) { $0.status = .invalidURL }
   }
 
+  // MARK: Auto-validation on appear (#38)
+
+  // Onboarding appears with a pre-filled URL (logout / failed launch auto-connect): the
+  // status check fires immediately — no focus/commit event needed — and the capability
+  // resolves so the sign-in step unlocks.
+  @Test func appearWithPrefilledURLAutoChecks() async {
+    let store = TestStore(
+      initialState: ConnectionFeature.State(serverURL: "http://mac.tailnet:9119")
+    ) {
+      ConnectionFeature()
+    } withDependencies: {
+      $0.hermesREST.status = { @Sendable _ in okStatus() }
+    }
+
+    await store.send(.onAppear)
+    await store.receive(\.checkServer) { $0.status = .checking }
+    await store.receive(\.serverStatusResponse) {
+      $0.capability = .tokenOnly
+      $0.status = .reachable(version: "0.16.0")
+    }
+  }
+
+  // First launch: nothing pre-filled, nothing to check — appear is a no-op.
+  @Test func appearWithEmptyURLDoesNotCheck() async {
+    let store = TestStore(initialState: ConnectionFeature.State(serverURL: "  ")) {
+      ConnectionFeature()
+    }
+    await store.send(.onAppear)
+  }
+
+  // A re-appear (popping back from the details screen) with a completed check must not
+  // re-fire and clobber the resolved status.
+  @Test func appearAfterCompletedCheckDoesNotRecheck() async {
+    let store = TestStore(
+      initialState: ConnectionFeature.State(
+        serverURL: "http://mac.tailnet:9119",
+        capability: .tokenOnly,
+        status: .reachable(version: "0.16.0")
+      )
+    ) {
+      ConnectionFeature()
+    }
+    await store.send(.onAppear)
+  }
+
   // MARK: Auto-validation (Task 2 — no Check button)
 
   @Test func editingURLResetsToIdleThenDebouncesAutoCheck() async {

--- a/HermesMobile/Sources/Features/ConnectionView.swift
+++ b/HermesMobile/Sources/Features/ConnectionView.swift
@@ -60,6 +60,9 @@ struct ConnectionView: View {
         methodHint
       }
     }
+    // Auto-validate a pre-filled server URL (after logout / a failed launch auto-connect)
+    // so the user doesn't have to focus the field to unlock sign-in (#38).
+    .onAppear { store.send(.onAppear) }
   }
 
   /// Always-visible honesty note under the token field: what a token grants, where it's


### PR DESCRIPTION
Closes #38

When onboarding appears with a pre-filled server URL (after logout or a failed launch auto-connect), the Hermes status/auth-capability check now fires automatically — the user no longer has to focus the field to unlock the sign-in step.

- New `ConnectionFeature.Action.onAppear` reuses the existing `.checkServer` path (no duplicated validation logic), so the normal checking/reachable/error states all apply.
- Guarded to a pristine `.idle` status with a non-empty URL: first launch (empty field) is a no-op, and a re-appear (e.g. popping back from the secure-connect details screen) never clobbers a completed or in-flight check. The `.idle` guard also keeps DemoMode and snapshot states (seeded `.reachable`) untouched.
- `ConnectionView` sends it via `.onAppear` — the view stays thin.

## Tests
- `appearWithPrefilledURLAutoChecks` — appear with a pre-filled URL → `checkServer` fires → capability resolves, no focus/commit event
- `appearWithEmptyURLDoesNotCheck` — whitespace-only field → no-op
- `appearAfterCompletedCheckDoesNotRecheck` — re-appear with a resolved status → no re-check

Full HermesKit suite passes (656 tests); snapshot suite green against existing baselines (no visual change).