### PR TITLE
Keep a running session alive across navigation and backgrounding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,17 +114,27 @@ build/test/distribution, and `docs/plans/completed/` for the full design history
   an `AppFeature`-owned **live-chat slot** (`liveChat: ChatFeature.State?` via `.ifLet`); the nav
   `path` holds only thin `ChatScreen` session-key markers, so popping destroys nothing. **Teardown
   is an `AppFeature` policy**, not a view event: idle pop / turn-end-while-detached / slot
-  replacement / archiving the slot's session / logout do `persistNow` + `.teardown`; a running
-  turn keeps streaming into the slot (list glow via `runningChanged`). Re-opening the slot's
-  session pushes the marker + `.reattached` — always hydrate, but **never cancel-and-redial a
-  healthy socket** (`connect` only when `status != .ready`; `ChatView.task` is gated by
-  `hasStarted`). The view's disappear action is `.viewDisappeared` (mic/voice cleanup only).
+  replacement / archiving the slot's session / logout run `teardownSlot` (`persistNow` →
+  `.teardown` → `.clearLiveChat` — the **nil-out is mandatory**: `ifLet` auto-cancel is the only
+  thing that reaches the un-ID'd one-shot RPC effects, so a replacement must route through it,
+  never just swap slot state); a running turn keeps streaming into the slot (list glow via
+  `runningChanged`). Re-opening the slot's session pushes the marker + `.reattached` — always
+  hydrate, but **never cancel-and-redial a healthy socket** (`.reattached` AND `.foreground`
+  `connect` only when `status != .ready`; `ChatView.task` is gated by `hasStarted`). The view's
+  disappearance is sent by the destination as **`AppFeature.chatViewDisappeared`** (never through
+  the child scope — a nil slot is guarded in the parent), which forwards `.viewDisappeared`
+  (mic/voice cleanup) and runs the idle-pop teardown only then, AFTER the pop animation — never
+  at `.popFrom` time (that would blank the outgoing screen).
 - **Backgrounding gets a ~30s grace** via `BackgroundTaskClient` (`begin(name) →
   AsyncStream<Void>` yielding once on early expiry; `#if canImport(UIKit)` liveValue wrapping
-  `beginBackgroundTask`, test-drivable expiry in `testValue`): `.background` with a running slot →
+  `beginBackgroundTask`, test-drivable expiry in `.inMemory()`): `.background` with a running slot →
   `persistNow` + begin (`CancelID.backgroundGrace`); expiry while still backgrounded → final
-  persist + `.teardownSocketOnly` (state stays in memory for the #26 foreground catch-up); `.active`
-  before expiry ends the task; idle/no-slot background = persist only, **no task, no battery burn**.
+  persist + `.teardownSocketOnly` (state stays in memory for the #26 foreground catch-up; the
+  client's expiration handler owns the `end()` bookkeeping); `.active` before expiry ends the
+  task, and a stale expiry racing `.active` is guarded to a no-op via the scene-phase flag
+  (`isSceneBackgrounded`); slot teardown releases the grace task early. An **idle slot**
+  backgrounds to persist-only and **no slot** is a no-op — either way **no task, no battery
+  burn**.
 - **Push-tap routing dedups against the slot** (#32) — `pushTapped` compares the pushed
   `session_id` to slot + path: matches slot with its marker on top → **no navigation** (in-place
   hydrate; badge bookkeeping still runs); matches slot from the list → push marker + `.reattached`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,25 @@ build/test/distribution, and `docs/plans/completed/` for the full design history
   `message.start` and clear it on complete/error/interrupt. On hydrate, **`running` decides
   whether the timer runs; the anchor only supplies the start instant** — a stopped turn with a
   stale anchor **discards** the anchor (no phantom timer).
+- **A running chat keeps its socket across navigation** (#33) — the open chat's state lives in
+  an `AppFeature`-owned **live-chat slot** (`liveChat: ChatFeature.State?` via `.ifLet`); the nav
+  `path` holds only thin `ChatScreen` session-key markers, so popping destroys nothing. **Teardown
+  is an `AppFeature` policy**, not a view event: idle pop / turn-end-while-detached / slot
+  replacement / archiving the slot's session / logout do `persistNow` + `.teardown`; a running
+  turn keeps streaming into the slot (list glow via `runningChanged`). Re-opening the slot's
+  session pushes the marker + `.reattached` — always hydrate, but **never cancel-and-redial a
+  healthy socket** (`connect` only when `status != .ready`; `ChatView.task` is gated by
+  `hasStarted`). The view's disappear action is `.viewDisappeared` (mic/voice cleanup only).
+- **Backgrounding gets a ~30s grace** via `BackgroundTaskClient` (`begin(name) →
+  AsyncStream<Void>` yielding once on early expiry; `#if canImport(UIKit)` liveValue wrapping
+  `beginBackgroundTask`, test-drivable expiry in `testValue`): `.background` with a running slot →
+  `persistNow` + begin (`CancelID.backgroundGrace`); expiry while still backgrounded → final
+  persist + `.teardownSocketOnly` (state stays in memory for the #26 foreground catch-up); `.active`
+  before expiry ends the task; idle/no-slot background = persist only, **no task, no battery burn**.
+- **Push-tap routing dedups against the slot** (#32) — `pushTapped` compares the pushed
+  `session_id` to slot + path: matches slot with its marker on top → **no navigation** (in-place
+  hydrate; badge bookkeeping still runs); matches slot from the list → push marker + `.reattached`;
+  different session → replace slot + **SET** the path to the single new marker (never stack).
 - **Session-list working glow is event-driven** via `ChatFeature.Delegate.runningChanged`
   (emitted on `message.start`/`complete`/`error` and the `session.resume` `running` flag),
   routed by `AppFeature` to `SessionListFeature` for an instant row-glow patch; the poll is only

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -73,7 +73,9 @@ public struct AppFeature {
     case autoConnectFailed(ServerConnection)
     /// The app's scene phase changed (foreground/background) — observed at the app shell and
     /// fanned out: `.active` reconnects + re-hydrates the open chat and refreshes the list;
-    /// `.background`/`.inactive` flushes the open chat's snapshot + anchor immediately.
+    /// `.background`/`.inactive` flushes the open chat's snapshot + anchor immediately, and
+    /// `.background` with a RUNNING turn additionally requests a finite background window
+    /// (`BackgroundTaskClient`) so the socket keeps streaming ~30s past suspension.
     case scenePhaseChanged(ScenePhase)
     /// A push notification was tapped — deep-link to its session (same path as a list tap) and,
     /// for an approval, clear its pending-approval badge entry (the user is now viewing it).
@@ -91,16 +93,22 @@ public struct AppFeature {
     /// Internal: clear the slot after its `.teardown` ran (pop-to-list policy). Nil-ing the
     /// slot also auto-cancels any straggler child effects (`ifLet` semantics).
     case clearLiveChat
+    /// Internal: the finite background window (`BackgroundTaskClient`) expired while still
+    /// backgrounded — final flush, then disconnect the socket cleanly
+    /// (`.teardownSocketOnly`), keeping the chat state in memory for the #26-preserving
+    /// foreground re-hydrate.
+    case backgroundGraceExpired
     case reauth(PresentationAction<ReauthFeature.Action>)
   }
 
-  /// One id for the long-running incoming-tap observer.
-  private enum CancelID { case pushTaps }
+  /// Ids for the long-running incoming-tap observer and the background-grace listener.
+  private enum CancelID { case pushTaps, backgroundGrace }
 
   @Dependency(\.keychain) var keychain
   @Dependency(\.preferences) var preferences
   @Dependency(\.hermesREST) var rest
   @Dependency(\.push) var push
+  @Dependency(\.backgroundTask) var backgroundTask
 
   public init() {}
 
@@ -167,17 +175,57 @@ public struct AppFeature {
         // auto-restore the nav stack on cold launch — opening a session is enough.
         switch phase {
         case .active:
-          // Foreground: reconnect + re-hydrate (via `session.resume`) the live chat (re-reads
-          // running/inflight/usage) and refresh the list immediately (don't wait for the poll).
+          // Foreground: release the background-execution window (cancel the grace listener;
+          // `end()` is idempotent — a no-op when none is active), then reconnect + re-hydrate
+          // (via `session.resume`) the live chat (re-reads running/inflight/usage) and refresh
+          // the list immediately (don't wait for the poll).
           return .merge(
+            .cancel(id: CancelID.backgroundGrace),
+            .run { [backgroundTask] _ in await backgroundTask.end() },
             state.liveChat != nil ? .send(.liveChat(.foreground)) : .none,
             state.home != nil ? .send(.home(.pulledToRefresh)) : .none
           )
-        case .background, .inactive:
+        case .background:
           // Backgrounding: flush the live chat's snapshot + anchor IMMEDIATELY (don't rely on
           // the 1s debounce) so a process kill can't lose the latest paint or the timer anchor.
+          guard let chat = state.liveChat else { return .none }
+          let flush: Effect<Action> = .send(.liveChat(.persistNow))
+          // A RUNNING turn buys itself a finite background window (~30s): the socket simply
+          // keeps streaming, no `ChatFeature` changes. If iOS expires the window while still
+          // backgrounded, the listener fires `.backgroundGraceExpired` → final flush + clean
+          // socket-only disconnect (state stays in memory for the #26-preserving foreground
+          // hydrate); catch-up is then the existing push + `.foreground` reconnect. An idle
+          // chat starts NO task — nothing to keep alive, no battery burn.
+          guard chat.isRunning else { return flush }
+          return .merge(
+            flush,
+            .run { [backgroundTask] send in
+              for await _ in await backgroundTask.begin("hermes.chat.background-grace") {
+                await send(.backgroundGraceExpired)
+              }
+            }
+            .cancellable(id: CancelID.backgroundGrace, cancelInFlight: true)
+          )
+        case .inactive:
+          // Transient occlusion (app switcher, notification shade): flush only — the process
+          // isn't suspending yet, so no background window is needed.
           return state.liveChat != nil ? .send(.liveChat(.persistNow)) : .none
         }
+
+      case .backgroundGraceExpired:
+        // The background window ran out while still backgrounded. Final flush, then cancel
+        // the socket ONLY — `liveChat` stays in memory so the foreground re-hydrate can
+        // preserve the live thinking/tool rows (#26). `end()` is the mandatory bookkeeping
+        // call (the client already ended the task inside its expiration handler, so this is
+        // an idempotent no-op — kept explicit).
+        guard state.liveChat != nil else {
+          return .run { [backgroundTask] _ in await backgroundTask.end() }
+        }
+        return .concatenate(
+          .send(.liveChat(.persistNow)),
+          .send(.liveChat(.teardownSocketOnly)),
+          .run { [backgroundTask] _ in await backgroundTask.end() }
+        )
 
       case let .pushTapped(tap):
         // Deep-link a tapped push to its session via the SAME path a list tap uses, so taps and

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -77,8 +77,10 @@ public struct AppFeature {
     /// `.background` with a RUNNING turn additionally requests a finite background window
     /// (`BackgroundTaskClient`) so the socket keeps streaming ~30s past suspension.
     case scenePhaseChanged(ScenePhase)
-    /// A push notification was tapped — deep-link to its session (same path as a list tap) and,
-    /// for an approval, clear its pending-approval badge entry (the user is now viewing it).
+    /// A push notification was tapped — deep-link to its session, routed by comparing the
+    /// tapped id against the live slot + path (#32): already on screen → badge bookkeeping
+    /// only; detached slot match → re-attach push; different session → replace the slot and
+    /// SET the path (never stack). Approval taps clear their pending-badge entry on view.
     case pushTapped(PushTap)
     case onboarding(ConnectionFeature.Action)
     case home(SessionListFeature.Action)
@@ -228,10 +230,9 @@ public struct AppFeature {
         )
 
       case let .pushTapped(tap):
-        // Deep-link a tapped push to its session via the SAME path a list tap uses, so taps and
-        // list-taps share one open-session flow. Prefer the loaded `Session` (carries a title);
-        // fall back to a minimal `Session(id:)` if it isn't in the list (the chat resumes by
-        // stored id and hydrates the title from `session.info`).
+        // Deep-link a tapped push to its session — routed by comparing `tap.sessionID`
+        // against the live slot + path (#32) so a tap for the already-open session never
+        // stacks a duplicate chat screen.
         //
         // Badge bookkeeping: an approval tap first MARKS the session pending (it's a relevant
         // approval), then opening it CLEARS that entry below — so a tap that opens nets to zero,
@@ -240,10 +241,27 @@ public struct AppFeature {
           state.pendingApprovalSessionIDs.insert(tap.sessionID)
         }
         guard state.home != nil else {
-          // No session list yet (e.g. still on onboarding) — can't open; the badge reflects the
-          // now-pending approval.
+          // No session list yet (e.g. cold launch still on onboarding) — can't open; the badge
+          // reflects the now-pending approval.
           return setBadge(state)
         }
+        // Matches the slot AND its marker is on the path (the chat is on screen) → NO
+        // navigation. Badge bookkeeping only: the user is now viewing it, so the pending
+        // entry clears (mark-then-clear nets zero); the content update arrives in place —
+        // the live socket is already streaming, and the tap's app activation fires the
+        // existing `.foreground` re-hydrate.
+        if let chat = state.liveChat,
+           (chat.storedSessionID ?? chat.liveSessionID) == tap.sessionID,
+           !state.path.isEmpty {
+          state.pendingApprovalSessionIDs.remove(tap.sessionID)
+          return setBadge(state)
+        }
+        // Otherwise share the SAME `openSession` flow a list tap uses: a detached slot match
+        // (user on the list) pushes the marker back and re-attaches live (no re-init, no dup);
+        // a different session replaces the slot and SETS the path to the single new marker
+        // (`fillLiveChat` resets rather than appends — no stacking on cold launch either).
+        // Prefer the loaded `Session` (carries a title); fall back to a minimal `Session(id:)`
+        // if it isn't in the list (the chat resumes by stored id and hydrates the title).
         let session = state.home?.sessions[id: tap.sessionID] ?? Session(id: tap.sessionID)
         // Opening clears the badge entry + marks current-viewing (handled in the openSession case).
         return .send(.home(.delegate(.openSession(session))))

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -8,7 +8,15 @@ public struct AppFeature {
   public struct State: Equatable {
     public var onboarding: ConnectionFeature.State
     public var home: SessionListFeature.State?
-    public var path: StackState<ChatFeature.State>
+    /// The navigation path holds only thin session-key markers (`ChatScreen.State`) — the
+    /// real chat state lives in the `liveChat` slot below, so popping a marker never
+    /// destroys the chat's state or effects by itself.
+    public var path: StackState<ChatScreen.State>
+    /// The app-owned "live chat slot": the one open (or detached-but-live) chat. Composed
+    /// via `.ifLet`, so its socket, reconnect backoff, thinking ticker, and debounced
+    /// persist are slot-rooted and survive navigation pops. One live session at a time —
+    /// opening a different session replaces the slot.
+    public var liveChat: ChatFeature.State?
     /// True during the launch auto-connect probe — `AppView` shows a brief placeholder
     /// instead of flashing the onboarding screen.
     public var autoConnecting: Bool
@@ -24,7 +32,8 @@ public struct AppFeature {
     public init(
       onboarding: ConnectionFeature.State = .init(),
       home: SessionListFeature.State? = nil,
-      path: StackState<ChatFeature.State> = .init(),
+      path: StackState<ChatScreen.State> = .init(),
+      liveChat: ChatFeature.State? = nil,
       autoConnecting: Bool = false,
       reauth: ReauthFeature.State? = nil,
       pendingApprovalSessionIDs: Set<String> = []
@@ -32,16 +41,20 @@ public struct AppFeature {
       self.onboarding = onboarding
       self.home = home
       self.path = path
+      self.liveChat = liveChat
       self.autoConnecting = autoConnecting
       self.reauth = reauth
       self.pendingApprovalSessionIDs = pendingApprovalSessionIDs
     }
 
-    /// The session the user is currently viewing — the top chat's session key
-    /// (`storedSessionID ?? liveSessionID`), or `nil` when no chat is open (or a new chat whose
-    /// id hasn't resolved yet). Drives foreground push suppression via `.onChange`.
+    /// The session the user is currently viewing — the live chat's session key
+    /// (`storedSessionID ?? liveSessionID`) while its marker is pushed, or `nil` when no
+    /// chat is on screen (or a new chat whose id hasn't resolved yet). A detached slot
+    /// (user on the list) reads `nil` so pushes for that session are NOT suppressed.
+    /// Drives foreground push suppression via `.onChange`.
     var currentViewingSessionID: String? {
-      path.last.flatMap { $0.storedSessionID ?? $0.liveSessionID }
+      guard !path.isEmpty else { return nil }
+      return liveChat.flatMap { $0.storedSessionID ?? $0.liveSessionID }
     }
   }
 
@@ -67,7 +80,17 @@ public struct AppFeature {
     case pushTapped(PushTap)
     case onboarding(ConnectionFeature.Action)
     case home(SessionListFeature.Action)
-    case path(StackActionOf<ChatFeature>)
+    case path(StackActionOf<ChatScreen>)
+    /// The live chat slot's actions — the chat is composed here (via `.ifLet`), NOT in the
+    /// navigation path, so its effects survive pops.
+    case liveChat(ChatFeature.Action)
+    /// Internal: fill the live-chat slot with a fresh chat and (re)set its path marker.
+    /// Used when opening while the slot is occupied — sequenced after the old slot's
+    /// `.teardown` so the outgoing chat's effects can't leak into the replacement.
+    case fillLiveChat(ChatFeature.State)
+    /// Internal: clear the slot after its `.teardown` ran (pop-to-list policy). Nil-ing the
+    /// slot also auto-cancels any straggler child effects (`ifLet` semantics).
+    case clearLiveChat
     case reauth(PresentationAction<ReauthFeature.Action>)
   }
 
@@ -139,22 +162,21 @@ public struct AppFeature {
         return .none
 
       case let .scenePhaseChanged(phase):
-        // Fan lifecycle out to the currently-open chat (top of the nav path, if any) and the
-        // session list. We do NOT auto-restore the nav stack on cold launch — opening a session
-        // is enough; this only re-syncs what's already on screen.
-        let topChatID = state.path.ids.last
+        // Fan lifecycle out to the live chat slot (if any) and the session list — no
+        // top-of-path hunting: the slot IS the one live chat, attached or not. We do NOT
+        // auto-restore the nav stack on cold launch — opening a session is enough.
         switch phase {
         case .active:
-          // Foreground: reconnect + re-hydrate (via `session.resume`) the open chat (re-reads
+          // Foreground: reconnect + re-hydrate (via `session.resume`) the live chat (re-reads
           // running/inflight/usage) and refresh the list immediately (don't wait for the poll).
           return .merge(
-            topChatID.map { .send(.path(.element(id: $0, action: .foreground))) } ?? .none,
+            state.liveChat != nil ? .send(.liveChat(.foreground)) : .none,
             state.home != nil ? .send(.home(.pulledToRefresh)) : .none
           )
         case .background, .inactive:
-          // Backgrounding: flush the open chat's snapshot + anchor IMMEDIATELY (don't rely on
+          // Backgrounding: flush the live chat's snapshot + anchor IMMEDIATELY (don't rely on
           // the 1s debounce) so a process kill can't lose the latest paint or the timer anchor.
-          return topChatID.map { .send(.path(.element(id: $0, action: .persistNow))) } ?? .none
+          return state.liveChat != nil ? .send(.liveChat(.persistNow)) : .none
         }
 
       case let .pushTapped(tap):
@@ -184,86 +206,159 @@ public struct AppFeature {
 
       case let .home(.delegate(.openSession(session))):
         guard let home = state.home else { return .none }
-        state.path.append(
-          // `resolvedTitle` keeps the server's "Untitled" placeholder out of the header
-          // (and the rename pre-fill); a real title arrives via `session.info` on resume.
-          // Carry the active profile so resume/history scope to the right `state.db`.
-          ChatFeature.State(
-            connection: home.connection,
-            resumeStoredID: session.id,
-            profileName: home.scopedProfileName,
-            title: session.resolvedTitle
-          )
-        )
         // Opening a session clears its pending-approval badge entry (the user is now viewing it).
         // The current-viewing marker is updated by the `.onChange(of: currentViewingSessionID)`
         // modifier below (one source of truth for nav-derived state).
         state.pendingApprovalSessionIDs.remove(session.id)
-        return setBadge(state)
+        let badge = setBadge(state)
+        // Re-opening the slot's OWN session (e.g. tapping the glowing row of a detached
+        // running turn): the accumulated live state must survive — a fresh
+        // `ChatFeature.State` would discard the detached thinking/tool/streaming rows.
+        // Push the marker back (the path is empty when coming from the list) and
+        // re-attach: hydrate against the live socket, reconnecting only if it died.
+        if let chat = state.liveChat,
+           (chat.storedSessionID ?? chat.liveSessionID) == session.id {
+          if state.path.isEmpty {
+            state.path.append(ChatScreen.State(sessionKey: session.id))
+          }
+          return .merge(badge, .send(.liveChat(.reattached)))
+        }
+        // `resolvedTitle` keeps the server's "Untitled" placeholder out of the header
+        // (and the rename pre-fill); a real title arrives via `session.info` on resume.
+        // Carry the active profile so resume/history scope to the right `state.db`.
+        let chat = ChatFeature.State(
+          connection: home.connection,
+          resumeStoredID: session.id,
+          profileName: home.scopedProfileName,
+          title: session.resolvedTitle
+        )
+        guard state.liveChat != nil else {
+          fillLiveChat(chat, into: &state)
+          return badge
+        }
+        // Slot occupied (e.g. a push tap while a chat is open): flush the old chat's
+        // snapshot, tear it down FIRST so its socket/effects can't feed events into the
+        // replacement, then fill the slot.
+        return .merge(
+          badge,
+          .concatenate(
+            .send(.liveChat(.persistNow)),
+            .send(.liveChat(.teardown)),
+            .send(.fillLiveChat(chat))
+          )
+        )
 
       case let .home(.delegate(.createSession(initialComposerText))):
         guard let home = state.home else { return .none }
         // New chats are created under the currently-selected profile. `initialComposerText`
         // (push "Ask agent to install") seeds the composer draft but is NOT auto-sent.
-        state.path.append(
-          ChatFeature.State(
-            connection: home.connection,
-            profileName: home.scopedProfileName,
-            composerText: initialComposerText ?? ""
-          )
+        let chat = ChatFeature.State(
+          connection: home.connection,
+          profileName: home.scopedProfileName,
+          composerText: initialComposerText ?? ""
         )
+        guard state.liveChat != nil else {
+          fillLiveChat(chat, into: &state)
+          return .none
+        }
+        // Slot occupied: flush + tear the old chat down before filling (same rule as open).
+        return .concatenate(
+          .send(.liveChat(.persistNow)),
+          .send(.liveChat(.teardown)),
+          .send(.fillLiveChat(chat))
+        )
+
+      case let .fillLiveChat(chat):
+        fillLiveChat(chat, into: &state)
         return .none
 
+      case .clearLiveChat:
+        // Pop-to-list teardown completed — drop the slot state. `ifLet` auto-cancels any
+        // remaining child effects on the nil-out.
+        state.liveChat = nil
+        return .none
+
+      case .path(.popFrom):
+        // Popped back to the session list. Keep-while-running policy: a RUNNING turn keeps
+        // its slot untouched — the socket streams on, rows accumulate detached, and the
+        // list's row glow tracks via `runningChanged` (whose `running: false` while
+        // detached tears the slot down below). An idle chat has nothing to keep alive —
+        // flush the snapshot, cancel everything, clear the slot.
+        guard let chat = state.liveChat else { return .none }
+        guard !chat.isRunning else { return .none }
+        return teardownSlot()
+
+      case let .home(.delegate(.sessionArchived(id))):
+        // The user archived a session from the list. If it's the slot's session (possibly
+        // detached mid-turn), tear the live chat down FIRST — its socket must not keep
+        // streaming into a session that's now archived. Any other session → nothing to do
+        // (the list's optimistic archive handles itself).
+        guard let chat = state.liveChat,
+              (chat.storedSessionID ?? chat.liveSessionID) == id
+        else { return .none }
+        return teardownSlot()
+
       case .home(.delegate(.disconnect)):
-        // Token cleared in Settings → tear down and return to onboarding.
+        // Token cleared in Settings → tear down and return to onboarding. Nil-ing the slot
+        // auto-cancels its effects (socket included).
         let connection = state.home?.connection
         state.path = .init()
+        state.liveChat = nil
         state.home = nil
         state.onboarding = .init()
         return unregisterPushOnLogout(connection: connection)
 
-      case .path(.element(id: _, action: .delegate(.sessionExpired))):
-        // A live (gated) session died. The chat already paused its own reconnect; raise the
-        // re-auth modal seeded from that chat's connection (server URL + regime + identity).
-        // Ignore if a modal is already up (only the first dead session raises it).
-        guard state.reauth == nil, let chat = state.path.last else { return .none }
+      case .liveChat(.delegate(.sessionExpired)):
+        // The live (gated) session died — attached or detached, the slot is the one chat.
+        // The chat already paused its own reconnect; raise the re-auth modal seeded from its
+        // connection (server URL + regime + identity). Ignore if a modal is already up.
+        guard state.reauth == nil, let chat = state.liveChat else { return .none }
         state.reauth = makeReauthState(for: chat.connection)
         return .none
 
       case let .reauth(.presented(.delegate(.reauthenticated(connection, sameUser)))):
         state.reauth = nil
         if sameUser {
-          // Same user → resume the dead chat in place with the fresh auth regime.
-          guard let id = state.path.ids.last else { return .none }
-          return .send(.path(.element(id: id, action: .resumeAfterReauth(connection))))
+          // Same user → resume the dead slot chat in place with the fresh auth regime.
+          guard state.liveChat != nil else { return .none }
+          return .send(.liveChat(.resumeAfterReauth(connection)))
         }
         // Different user signed in → drop everything identity-scoped and force a fresh list.
         preferences.clearIdentityScopedPrefs()
         state.path = .init()
+        state.liveChat = nil
         state.home = SessionListFeature.State(connection: connection)
         return .none
 
       case .reauth(.presented(.delegate(.quit))):
         // "Quit to start" → full logout (Keychain session + every pref) → onboarding.
-        let connection = state.home?.connection ?? state.path.last?.connection
+        let connection = state.home?.connection ?? state.liveChat?.connection
         try? keychain.deleteSession()
         preferences.clearServerURL()
         preferences.clearIdentityScopedPrefs()
         preferences.saveGroupingMode(.default)
         state.reauth = nil
         state.path = .init()
+        state.liveChat = nil
         state.home = nil
         state.onboarding = .init()
         return unregisterPushOnLogout(connection: connection)
 
-      case let .path(.element(id: _, action: .delegate(.runningChanged(sessionID, running)))):
-        // Route the open chat's authoritative working-state change to the session list so its
+      case let .liveChat(.delegate(.runningChanged(sessionID, running))):
+        // Route the live chat's authoritative working-state change to the session list so its
         // row glow clears/lights INSTANTLY (event-driven), without waiting for the next poll.
         // The poll stays the backstop for not-open sessions. No `home` → nothing to patch.
-        guard state.home != nil else { return .none }
-        return .send(.home(.setSessionRunning(id: sessionID, running: running)))
+        let glow: Effect<Action> = state.home != nil
+          ? .send(.home(.setSessionRunning(id: sessionID, running: running)))
+          : .none
+        // A DETACHED slot (no marker in the path — the user popped to the list) only
+        // outlives the pop while its turn runs. The turn ending — `message.complete`,
+        // `.error`, or a foreground hydrate confirming `running == false` — means there's
+        // nothing left to keep alive: flush the snapshot, then tear the slot down.
+        guard !running, state.path.isEmpty, state.liveChat != nil else { return glow }
+        return .concatenate(glow, teardownSlot())
 
-      case .onboarding, .home, .path, .reauth:
+      case .onboarding, .home, .path, .reauth, .liveChat:
         return .none
       }
     }
@@ -273,10 +368,13 @@ public struct AppFeature {
     .ifLet(\.$reauth, action: \.reauth) {
       ReauthFeature()
     }
-    .forEach(\.path, action: \.path) {
+    .ifLet(\.liveChat, action: \.liveChat) {
       ChatFeature()
     }
-    // Keep the push bridge's "currently viewing" session in sync with the top of the nav stack
+    .forEach(\.path, action: \.path) {
+      ChatScreen()
+    }
+    // Keep the push bridge's "currently viewing" session in sync with the slot + nav stack
     // (one source of truth, evaluated AFTER the child reducers so pops/dismissals AND a new chat
     // resolving its `liveSessionID` are reflected) so a foreground push for the on-screen session
     // is suppressed. Opening, popping back to the list, and id-resolution all flow through here.
@@ -285,6 +383,27 @@ public struct AppFeature {
         .run { [push] _ in push.setCurrentSession(newValue) }
       }
     }
+  }
+
+  /// The standard "slot is done" sequence (idle pop, detached turn completion, archived
+  /// session): flush the snapshot + turn anchor first (the debounced persist is about to be
+  /// cancelled), cancel every long-running chat effect, then clear the slot (`ifLet`
+  /// auto-cancels any stragglers on the nil-out).
+  private func teardownSlot() -> Effect<Action> {
+    .concatenate(
+      .send(.liveChat(.persistNow)),
+      .send(.liveChat(.teardown)),
+      .send(.clearLiveChat)
+    )
+  }
+
+  /// Fill the live-chat slot and (re)set the navigation path to that chat's single marker.
+  /// One slot ↔ one marker: the path never holds more than one chat screen, so replacing the
+  /// contents (rather than appending) can't stack duplicates.
+  private func fillLiveChat(_ chat: ChatFeature.State, into state: inout State) {
+    state.liveChat = chat
+    state.path.removeAll()
+    state.path.append(ChatScreen.State(sessionKey: chat.storedSessionID))
   }
 
   /// Best-effort push cleanup on logout: unregister the last-known device token with the

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -28,6 +28,10 @@ public struct AppFeature {
     /// entry (and recomputes the badge). A small dedicated count — distinct from the list's
     /// per-session *unread* (`seenCounts`) concept, which tracks message deltas, not approvals.
     public var pendingApprovalSessionIDs: Set<String>
+    /// Whether the scene is currently backgrounded (set on `.background`, cleared on
+    /// `.active`). Guards `.backgroundGraceExpired`: an expiry whose send escaped just as
+    /// the user returned must not tear down the socket `.active` freshly redialed.
+    var isSceneBackgrounded = false
 
     public init(
       onboarding: ConnectionFeature.State = .init(),
@@ -54,7 +58,7 @@ public struct AppFeature {
     /// Drives foreground push suppression via `.onChange`.
     var currentViewingSessionID: String? {
       guard !path.isEmpty else { return nil }
-      return liveChat.flatMap { $0.storedSessionID ?? $0.liveSessionID }
+      return liveChat?.sessionKey
     }
   }
 
@@ -85,15 +89,25 @@ public struct AppFeature {
     case onboarding(ConnectionFeature.Action)
     case home(SessionListFeature.Action)
     case path(StackActionOf<ChatScreen>)
+    /// The pushed chat view finished leaving the screen (sent by the destination in
+    /// `AppView` — never through the child scope, so a nil slot can be guarded here
+    /// instead of tripping the `ifLet` nil-child warning). Forwards the view-session
+    /// cleanup (`.viewDisappeared`) and applies the pop-to-list teardown policy AFTER the
+    /// pop animation — tearing down at `.popFrom` time would blank the outgoing screen
+    /// mid-animation.
+    case chatViewDisappeared
     /// The live chat slot's actions — the chat is composed here (via `.ifLet`), NOT in the
     /// navigation path, so its effects survive pops.
     case liveChat(ChatFeature.Action)
     /// Internal: fill the live-chat slot with a fresh chat and (re)set its path marker.
     /// Used when opening while the slot is occupied — sequenced after the old slot's
-    /// `.teardown` so the outgoing chat's effects can't leak into the replacement.
+    /// `.teardown` AND `.clearLiveChat` (the nil-out is what cancels the outgoing chat's
+    /// un-ID'd one-shot RPC effects) so nothing can leak into the replacement.
     case fillLiveChat(ChatFeature.State)
-    /// Internal: clear the slot after its `.teardown` ran (pop-to-list policy). Nil-ing the
-    /// slot also auto-cancels any straggler child effects (`ifLet` semantics).
+    /// Internal: clear the slot after its `.teardown` ran (`teardownSlot`). Nil-ing the
+    /// slot makes `ifLet` cancel every remaining child effect — including one-shot RPCs
+    /// that carry no cancel ID. Does not touch the path (a replacement resets it in the
+    /// immediately-following `.fillLiveChat`).
     case clearLiveChat
     /// Internal: the finite background window (`BackgroundTaskClient`) expired while still
     /// backgrounded — final flush, then disconnect the socket cleanly
@@ -105,6 +119,11 @@ public struct AppFeature {
 
   /// Ids for the long-running incoming-tap observer and the background-grace listener.
   private enum CancelID { case pushTaps, backgroundGrace }
+
+  /// Name of the finite background task requested while a running turn is backgrounded
+  /// (shows up in OS background-task diagnostics). Tests re-type the literal on purpose —
+  /// an accidental rename should fail the suite, not silently follow the constant.
+  private static let backgroundGraceTaskName = "hermes.chat.background-grace"
 
   @Dependency(\.keychain) var keychain
   @Dependency(\.preferences) var preferences
@@ -178,9 +197,11 @@ public struct AppFeature {
         switch phase {
         case .active:
           // Foreground: release the background-execution window (cancel the grace listener;
-          // `end()` is idempotent — a no-op when none is active), then reconnect + re-hydrate
-          // (via `session.resume`) the live chat (re-reads running/inflight/usage) and refresh
-          // the list immediately (don't wait for the poll).
+          // `end()` is idempotent — a no-op when none is active), then re-hydrate the live
+          // chat via `.foreground` (which reconnects only if the socket died — a socket the
+          // grace window kept alive is reused, not redialed) and refresh the list
+          // immediately (don't wait for the poll).
+          state.isSceneBackgrounded = false
           return .merge(
             .cancel(id: CancelID.backgroundGrace),
             .run { [backgroundTask] _ in await backgroundTask.end() },
@@ -190,6 +211,7 @@ public struct AppFeature {
         case .background:
           // Backgrounding: flush the live chat's snapshot + anchor IMMEDIATELY (don't rely on
           // the 1s debounce) so a process kill can't lose the latest paint or the timer anchor.
+          state.isSceneBackgrounded = true
           guard let chat = state.liveChat else { return .none }
           let flush: Effect<Action> = .send(.liveChat(.persistNow))
           // A RUNNING turn buys itself a finite background window (~30s): the socket simply
@@ -202,7 +224,7 @@ public struct AppFeature {
           return .merge(
             flush,
             .run { [backgroundTask] send in
-              for await _ in await backgroundTask.begin("hermes.chat.background-grace") {
+              for await _ in await backgroundTask.begin(Self.backgroundGraceTaskName) {
                 await send(.backgroundGraceExpired)
               }
             }
@@ -217,16 +239,16 @@ public struct AppFeature {
       case .backgroundGraceExpired:
         // The background window ran out while still backgrounded. Final flush, then cancel
         // the socket ONLY — `liveChat` stays in memory so the foreground re-hydrate can
-        // preserve the live thinking/tool rows (#26). `end()` is the mandatory bookkeeping
-        // call (the client already ended the task inside its expiration handler, so this is
-        // an idempotent no-op — kept explicit).
-        guard state.liveChat != nil else {
-          return .run { [backgroundTask] _ in await backgroundTask.end() }
-        }
+        // preserve the live thinking/tool rows (#26). No explicit `end()` here: the client
+        // performed the mandatory end bookkeeping inside its expiration handler before
+        // yielding. Guards: an expiry whose send escaped just as `.active` cancelled the
+        // listener must be a no-op — `.active` already redialed, and tearing that fresh
+        // socket down would strand the chat with no reconnect scheduled. Likewise nothing
+        // to do when the slot was already torn down (e.g. the detached turn ended).
+        guard state.isSceneBackgrounded, state.liveChat != nil else { return .none }
         return .concatenate(
           .send(.liveChat(.persistNow)),
-          .send(.liveChat(.teardownSocketOnly)),
-          .run { [backgroundTask] _ in await backgroundTask.end() }
+          .send(.liveChat(.teardownSocketOnly))
         )
 
       case let .pushTapped(tap):
@@ -245,14 +267,12 @@ public struct AppFeature {
           // reflects the now-pending approval.
           return setBadge(state)
         }
-        // Matches the slot AND its marker is on the path (the chat is on screen) → NO
-        // navigation. Badge bookkeeping only: the user is now viewing it, so the pending
-        // entry clears (mark-then-clear nets zero); the content update arrives in place —
-        // the live socket is already streaming, and the tap's app activation fires the
-        // existing `.foreground` re-hydrate.
-        if let chat = state.liveChat,
-           (chat.storedSessionID ?? chat.liveSessionID) == tap.sessionID,
-           !state.path.isEmpty {
+        // The tapped session is the one ALREADY on screen (slot match + marker on the
+        // path) → NO navigation. Badge bookkeeping only: the user is now viewing it, so
+        // the pending entry clears (mark-then-clear nets zero); the content update arrives
+        // in place — the live socket is already streaming, and the tap's app activation
+        // fires the existing `.foreground` re-hydrate.
+        if state.currentViewingSessionID == tap.sessionID {
           state.pendingApprovalSessionIDs.remove(tap.sessionID)
           return setBadge(state)
         }
@@ -282,8 +302,10 @@ public struct AppFeature {
         // `ChatFeature.State` would discard the detached thinking/tool/streaming rows.
         // Push the marker back (the path is empty when coming from the list) and
         // re-attach: hydrate against the live socket, reconnecting only if it died.
-        if let chat = state.liveChat,
-           (chat.storedSessionID ?? chat.liveSessionID) == session.id {
+        if let chat = state.liveChat, chat.sessionKey == session.id {
+          // Defensive guard: the path is normally empty here (re-opens come from the list,
+          // and an on-screen match short-circuits in `pushTapped` before reaching this
+          // delegate) — but a double-delivered open must not stack a second marker.
           if state.path.isEmpty {
             state.path.append(ChatScreen.State(sessionKey: session.id))
           }
@@ -302,17 +324,10 @@ public struct AppFeature {
           fillLiveChat(chat, into: &state)
           return badge
         }
-        // Slot occupied (e.g. a push tap while a chat is open): flush the old chat's
-        // snapshot, tear it down FIRST so its socket/effects can't feed events into the
-        // replacement, then fill the slot.
-        return .merge(
-          badge,
-          .concatenate(
-            .send(.liveChat(.persistNow)),
-            .send(.liveChat(.teardown)),
-            .send(.fillLiveChat(chat))
-          )
-        )
+        // Slot occupied (e.g. a push tap while a chat is open): replace it — the old chat
+        // must be fully torn down (through the nil-out, so even its un-ID'd one-shot RPC
+        // effects are cancelled) before the new chat fills the slot.
+        return .merge(badge, teardownSlot(thenFill: chat))
 
       case let .home(.delegate(.createSession(initialComposerText))):
         guard let home = state.home else { return .none }
@@ -327,12 +342,9 @@ public struct AppFeature {
           fillLiveChat(chat, into: &state)
           return .none
         }
-        // Slot occupied: flush + tear the old chat down before filling (same rule as open).
-        return .concatenate(
-          .send(.liveChat(.persistNow)),
-          .send(.liveChat(.teardown)),
-          .send(.fillLiveChat(chat))
-        )
+        // Slot occupied: flush + fully tear the old chat down before filling (same rule
+        // as open — the replacement goes through the nil-out).
+        return teardownSlot(thenFill: chat)
 
       case let .fillLiveChat(chat):
         fillLiveChat(chat, into: &state)
@@ -345,23 +357,38 @@ public struct AppFeature {
         return .none
 
       case .path(.popFrom):
-        // Popped back to the session list. Keep-while-running policy: a RUNNING turn keeps
-        // its slot untouched — the socket streams on, rows accumulate detached, and the
-        // list's row glow tracks via `runningChanged` (whose `running: false` while
-        // detached tears the slot down below). An idle chat has nothing to keep alive —
-        // flush the snapshot, cancel everything, clear the slot.
+        // Popped back to the session list. Nothing to do at pop-START: the teardown policy
+        // runs on `.chatViewDisappeared` (below), once the pop animation has finished —
+        // clearing the slot here would blank the outgoing screen mid-animation and route
+        // the view's disappearance into a nil child.
+        return .none
+
+      case .chatViewDisappeared:
+        // The pushed chat view finished leaving the screen: the pop animation completed,
+        // or its marker was swapped by a slot replacement. Forward the view-session
+        // cleanup (mic/voice) to whatever chat owns the slot, then apply the pop policy:
+        // a RUNNING detached turn keeps its slot untouched — the socket streams on, rows
+        // accumulate, and the list's row glow tracks via `runningChanged` (whose
+        // `running: false` while detached tears the slot down below). An idle detached
+        // chat has nothing to keep alive — flush the snapshot, cancel everything, clear
+        // the slot. A non-empty path means the disappearance came from a slot replacement
+        // (the new chat is on screen) → cleanup only. No slot (logout/quit/teardown
+        // already cleared it) → no-op.
         guard let chat = state.liveChat else { return .none }
-        guard !chat.isRunning else { return .none }
-        return teardownSlot()
+        let cleanup: Effect<Action> = .send(.liveChat(.viewDisappeared))
+        guard state.path.isEmpty, !chat.isRunning else { return cleanup }
+        return .concatenate(cleanup, teardownSlot())
 
       case let .home(.delegate(.sessionArchived(id))):
         // The user archived a session from the list. If it's the slot's session (possibly
         // detached mid-turn), tear the live chat down FIRST — its socket must not keep
         // streaming into a session that's now archived. Any other session → nothing to do
         // (the list's optimistic archive handles itself).
-        guard let chat = state.liveChat,
-              (chat.storedSessionID ?? chat.liveSessionID) == id
-        else { return .none }
+        guard let chat = state.liveChat, chat.sessionKey == id else { return .none }
+        // Deliberate asymmetry: if the archive PATCH later FAILS, the list restores the
+        // row (optimistic rollback) but the slot stays torn down — re-opening simply
+        // resumes the session fresh. Resurrecting live slot state for a rare failure path
+        // isn't worth replaying the teardown.
         return teardownSlot()
 
       case .home(.delegate(.disconnect)):
@@ -451,15 +478,32 @@ public struct AppFeature {
     }
   }
 
-  /// The standard "slot is done" sequence (idle pop, detached turn completion, archived
-  /// session): flush the snapshot + turn anchor first (the debounced persist is about to be
-  /// cancelled), cancel every long-running chat effect, then clear the slot (`ifLet`
-  /// auto-cancels any stragglers on the nil-out).
-  private func teardownSlot() -> Effect<Action> {
-    .concatenate(
+  /// The standard "slot is done" sequence (idle view-disappearance, detached turn
+  /// completion, archived session, slot replacement): flush the snapshot + turn anchor
+  /// first (the debounced persist is about to be cancelled), cancel every long-running
+  /// chat effect, then clear the slot — the nil-out makes `ifLet` cancel ALL remaining
+  /// child effects, including the un-ID'd one-shot RPCs (hydrate, submit, rename …) whose
+  /// results must never reduce into a replacement chat. Passing `thenFill` replaces the
+  /// slot with a fresh chat right after the clear. Any background grace window is released
+  /// early in parallel (idempotent no-ops in the foreground) — a torn-down slot has
+  /// nothing left for the OS task to keep alive.
+  ///
+  /// The action chain is delivered atomically: `Effect.send` emits synchronously, so the
+  /// store drains persist → teardown → clear (→ fill) in one send loop — no user action
+  /// can interleave between the steps.
+  private func teardownSlot(thenFill replacement: ChatFeature.State? = nil) -> Effect<Action> {
+    var chain: [Effect<Action>] = [
       .send(.liveChat(.persistNow)),
       .send(.liveChat(.teardown)),
-      .send(.clearLiveChat)
+      .send(.clearLiveChat),
+    ]
+    if let replacement {
+      chain.append(.send(.fillLiveChat(replacement)))
+    }
+    return .merge(
+      .cancel(id: CancelID.backgroundGrace),
+      .run { [backgroundTask] _ in await backgroundTask.end() },
+      .concatenate(chain)
     )
   }
 
@@ -469,7 +513,7 @@ public struct AppFeature {
   private func fillLiveChat(_ chat: ChatFeature.State, into state: inout State) {
     state.liveChat = chat
     state.path.removeAll()
-    state.path.append(ChatScreen.State(sessionKey: chat.storedSessionID))
+    state.path.append(ChatScreen.State(sessionKey: chat.sessionKey))
   }
 
   /// Best-effort push cleanup on logout: unregister the last-known device token with the

--- a/HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift
@@ -1,0 +1,206 @@
+import ComposableArchitecture
+import DependenciesMacros
+import Foundation
+
+/// Requests a finite window of background execution (~30s) so the gateway socket can keep
+/// streaming after the app is backgrounded mid-turn (keep-running-session-alive plan).
+/// Wraps `UIApplication.beginBackgroundTask`/`endBackgroundTask` behind a dependency so
+/// `AppFeature` stays testable and never touches UIKit directly. The client owns the
+/// mandatory end-on-expiry bookkeeping: every begun task is ended exactly once — via
+/// `end()`, on replacement by a newer `begin`, or inside the expiration handler (where
+/// iOS requires it before the process is suspended).
+@DependencyClient
+public struct BackgroundTaskClient: Sendable {
+  /// Start a finite background task. The returned stream yields **once** if iOS expires
+  /// the task early (the ~30s window ran out while still backgrounded), then finishes; it
+  /// finishes without yielding when the task is ended normally (`end()` or replacement).
+  /// Beginning while a task is already active replaces it (the prior task is ended and
+  /// its stream finishes without a yield).
+  public var begin: @Sendable (_ name: String) async -> AsyncStream<Void> = { _ in .finished }
+  /// End the active background task, returning execution to normal suspension rules.
+  /// Idempotent — a no-op when no task is active (safe to call on `.active` unconditionally).
+  public var end: @Sendable () async -> Void
+}
+
+extension BackgroundTaskClient: DependencyKey {
+  /// No-op double: `begin` grants nothing (already-finished stream, no expiry ever), `end`
+  /// does nothing. Override with `.inMemory()` to drive expiry in tests. (Spelled out so
+  /// the `@DependencyClient` macro's unimplemented closures don't leak into the default.)
+  public static var testValue: BackgroundTaskClient {
+    BackgroundTaskClient(
+      begin: { _ in .finished },
+      end: {}
+    )
+  }
+}
+
+public extension DependencyValues {
+  var backgroundTask: BackgroundTaskClient {
+    get { self[BackgroundTaskClient.self] }
+    set { self[BackgroundTaskClient.self] = newValue }
+  }
+}
+
+// MARK: - In-memory (deterministic test variant)
+
+/// Thread-safe bookkeeping for the in-memory client: one active task at a time, with the
+/// same end-exactly-once rules as the live UIKit wrapper.
+private final class BackgroundTaskBox: @unchecked Sendable {
+  private let lock = NSLock()
+  private var _activeTaskName: String?
+  private var _continuation: AsyncStream<Void>.Continuation?
+  private var _beginCount = 0
+  private var _endCount = 0
+
+  var activeTaskName: String? { lock.withLock { _activeTaskName } }
+  var beginCount: Int { lock.withLock { _beginCount } }
+  var endCount: Int { lock.withLock { _endCount } }
+
+  func begin(name: String) -> AsyncStream<Void> {
+    // Replace semantics: the prior task (if any) is ended, its stream finishing silently.
+    finishActive(expired: false)
+    let (stream, continuation) = AsyncStream<Void>.makeStream()
+    lock.withLock {
+      _activeTaskName = name
+      _continuation = continuation
+      _beginCount += 1
+    }
+    return stream
+  }
+
+  func end() {
+    finishActive(expired: false)
+  }
+
+  /// Simulate iOS expiring the active task: yield once, finish, and end the task (the
+  /// live wrapper's expiration handler does the same mandatory bookkeeping).
+  func expire() {
+    finishActive(expired: true)
+  }
+
+  private func finishActive(expired: Bool) {
+    let continuation: AsyncStream<Void>.Continuation? = lock.withLock {
+      guard _activeTaskName != nil else { return nil }
+      defer {
+        _activeTaskName = nil
+        _continuation = nil
+        _endCount += 1
+      }
+      return _continuation
+    }
+    guard let continuation else { return }
+    if expired { continuation.yield(()) }
+    continuation.finish()
+  }
+}
+
+public extension BackgroundTaskClient {
+  /// A deterministic, controllable client for tests: `expire()` drives the early-expiry
+  /// yield, and spy properties expose begin/end bookkeeping. Mirrors the
+  /// `AudioRecorderClient` / `PushClient` in-memory variants.
+  struct InMemory: Sendable {
+    public let client: BackgroundTaskClient
+    private let box: BackgroundTaskBox
+
+    public init() {
+      let box = BackgroundTaskBox()
+      self.box = box
+      self.client = BackgroundTaskClient(
+        begin: { name in box.begin(name: name) },
+        end: { box.end() }
+      )
+    }
+
+    /// Simulate iOS expiring the active task early (yields once into the `begin` stream).
+    public func expire() { box.expire() }
+    /// The name of the currently active task, or `nil` when none is running.
+    public var activeTaskName: String? { box.activeTaskName }
+    /// How many tasks have been begun (spy hook for tests).
+    public var beginCount: Int { box.beginCount }
+    /// How many tasks have been ended — explicitly, by replacement, or by expiry.
+    public var endCount: Int { box.endCount }
+  }
+
+  /// Convenience: a controllable in-memory client + handle for driving expiry.
+  static func inMemory() -> InMemory { InMemory() }
+}
+
+// MARK: - Live (iOS only)
+
+// `UIApplication.beginBackgroundTask` is iOS-only; the package is also built/tested on
+// macOS via `swift test`, so the live wrapper is compiled in only where UIKit exists.
+// Elsewhere `liveValue` falls back to the no-op double (no background-task API).
+#if canImport(UIKit)
+  import UIKit
+
+  /// Owns the single active `UIBackgroundTaskIdentifier` and the mandatory bookkeeping:
+  /// every begun task is ended exactly once — explicitly via `end()`, on replacement by a
+  /// newer `begin`, or in the expiration handler (iOS kills apps that skip that call).
+  private final class LiveBackgroundTaskBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var taskID: UIBackgroundTaskIdentifier = .invalid
+    private var continuation: AsyncStream<Void>.Continuation?
+
+    @MainActor
+    func begin(name: String) -> AsyncStream<Void> {
+      // Replace semantics: end any prior task first (its stream finishes without a yield).
+      finishActive(expired: false)
+      let (stream, continuation) = AsyncStream<Void>.makeStream()
+      let id = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
+        // The expiration handler is invoked on the main thread; iOS mandates ending the
+        // task synchronously here, after we let the policy layer react via the yield.
+        MainActor.assumeIsolated {
+          self?.finishActive(expired: true)
+        }
+      }
+      guard id != .invalid else {
+        // Background execution unavailable (e.g. disabled) — behave like instant expiry
+        // so the caller falls through to its clean-disconnect path.
+        continuation.yield(())
+        continuation.finish()
+        return stream
+      }
+      lock.withLock {
+        self.taskID = id
+        self.continuation = continuation
+      }
+      return stream
+    }
+
+    @MainActor
+    func end() {
+      finishActive(expired: false)
+    }
+
+    @MainActor
+    private func finishActive(expired: Bool) {
+      let (id, continuation) = lock.withLock {
+        defer {
+          taskID = .invalid
+          self.continuation = nil
+        }
+        return (taskID, self.continuation)
+      }
+      if expired { continuation?.yield(()) }
+      continuation?.finish()
+      if id != .invalid {
+        UIApplication.shared.endBackgroundTask(id)
+      }
+    }
+  }
+
+  extension BackgroundTaskClient {
+    public static var liveValue: BackgroundTaskClient {
+      let box = LiveBackgroundTaskBox()
+      return BackgroundTaskClient(
+        begin: { name in await box.begin(name: name) },
+        end: { await box.end() }
+      )
+    }
+  }
+#else
+  extension BackgroundTaskClient {
+    /// No background-task API off-device (macOS `swift test`): the no-op double.
+    public static var liveValue: BackgroundTaskClient { testValue }
+  }
+#endif

--- a/HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift
@@ -136,21 +136,36 @@ public extension BackgroundTaskClient {
   /// Owns the single active `UIBackgroundTaskIdentifier` and the mandatory bookkeeping:
   /// every begun task is ended exactly once — explicitly via `end()`, on replacement by a
   /// newer `begin`, or in the expiration handler (iOS kills apps that skip that call).
-  private final class LiveBackgroundTaskBox: @unchecked Sendable {
-    private let lock = NSLock()
+  ///
+  /// Synchronization is `@MainActor` isolation alone (no lock): `UIApplication` forces the
+  /// main actor on every path anyway — `begin`/`end` hop via the client's async closures,
+  /// and iOS invokes the expiration handler on the main thread (`assumeIsolated`) — so
+  /// actor isolation covers all state access. (The NSLock-only box pattern elsewhere —
+  /// `DebugLogClient.Buffer`, `PushClient.PushBox` — fits boxes with no main-actor
+  /// requirement; this one has one, so it uses the actor instead.)
+  @MainActor
+  private final class LiveBackgroundTaskBox {
     private var taskID: UIBackgroundTaskIdentifier = .invalid
     private var continuation: AsyncStream<Void>.Continuation?
+    /// Monotonic identity of the active task, bumped every time one is finished. The
+    /// expiration handler captures the generation of the task it was registered FOR and
+    /// no-ops unless it still matches — a stale handler (its task already ended or was
+    /// replaced) must never yield into, or end, a REPLACEMENT task's stream.
+    private var generation = 0
 
-    @MainActor
+    nonisolated init() {}
+
     func begin(name: String) -> AsyncStream<Void> {
       // Replace semantics: end any prior task first (its stream finishes without a yield).
       finishActive(expired: false)
       let (stream, continuation) = AsyncStream<Void>.makeStream()
+      let gen = generation
       let id = UIApplication.shared.beginBackgroundTask(withName: name) { [weak self] in
         // The expiration handler is invoked on the main thread; iOS mandates ending the
         // task synchronously here, after we let the policy layer react via the yield.
+        // Scoped to this task's generation so it can't finish a replacement's task.
         MainActor.assumeIsolated {
-          self?.finishActive(expired: true)
+          self?.finishActive(expired: true, ifGeneration: gen)
         }
       }
       guard id != .invalid else {
@@ -160,31 +175,27 @@ public extension BackgroundTaskClient {
         continuation.finish()
         return stream
       }
-      lock.withLock {
-        self.taskID = id
-        self.continuation = continuation
-      }
+      taskID = id
+      self.continuation = continuation
       return stream
     }
 
-    @MainActor
     func end() {
       finishActive(expired: false)
     }
 
-    @MainActor
-    private func finishActive(expired: Bool) {
-      let (id, continuation) = lock.withLock {
-        defer {
-          taskID = .invalid
-          self.continuation = nil
-        }
-        return (taskID, self.continuation)
-      }
-      if expired { continuation?.yield(()) }
-      continuation?.finish()
-      if id != .invalid {
-        UIApplication.shared.endBackgroundTask(id)
+    private func finishActive(expired: Bool, ifGeneration expected: Int? = nil) {
+      // A generation-scoped call (the expiration handler) is stale once the task it
+      // was registered for has been finished — the bump below invalidated it.
+      if let expected, expected != generation { return }
+      generation += 1
+      let finished = (id: taskID, continuation: continuation)
+      taskID = .invalid
+      continuation = nil
+      if expired { finished.continuation?.yield(()) }
+      finished.continuation?.finish()
+      if finished.id != .invalid {
+        UIApplication.shared.endBackgroundTask(finished.id)
       }
     }
   }

--- a/HermesKit/Sources/HermesKit/Clients/HermesGatewayClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/HermesGatewayClient.swift
@@ -69,6 +69,16 @@ public enum GatewayError: Error, Equatable, Sendable {
     return false
   }
 
+  /// True when a per-request RPC timeout fired (`timedOut`). Over a HALF-OPEN socket (e.g. a
+  /// stale connection after process suspension / NAT rebind) this is the first — and possibly
+  /// only — transport symptom for minutes: the receive loop may not finish (no `.gatewayClosed`)
+  /// even though nothing can get through. Callers should treat it as transport-shaped, like
+  /// `isDisconnected`, when deciding whether to redial.
+  public var isTimedOut: Bool {
+    if case .timedOut = self { return true }
+    return false
+  }
+
   /// True when the server rejected the request because the live runtime session id is stale
   /// (e.g. after a background→foreground the agent rebuilt/invalidated the in-memory session).
   /// `InboundFrame` keeps only the error message, so we match the server's stable

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -257,6 +257,14 @@ public struct ChatFeature {
     /// persist — and release the mic. `AppFeature` flushes the snapshot (`.persistNow`)
     /// before this where the pending debounce matters.
     case teardown
+    /// Background-grace expiry (sent by `AppFeature`, never the view): the finite
+    /// background window ran out while still backgrounded — cancel the socket + reconnect
+    /// backoff CLEANLY but keep ALL chat state in memory (transcript, live thinking/tool
+    /// row pointers, composer draft), so the next `.foreground` reconnect re-hydrates with
+    /// the #26 live-row preservation intact. Status flips to `.reconnecting` (the socket
+    /// is genuinely gone), so a later `.reattached` reconnects instead of hydrating a
+    /// dead socket.
+    case teardownSocketOnly
     /// Scroll-up reached the top of the current window: reveal another `pageSize` of older
     /// rows from the in-memory transcript (client-side only — no network call).
     case loadOlderRequested
@@ -425,6 +433,20 @@ public struct ChatFeature {
           .cancel(id: CancelID.persist),
           // Release the mic/session if we leave mid-recording.
           wasRecording ? .run { [audioRecorder] _ in await audioRecorder.cancel() } : .none
+        )
+
+      case .teardownSocketOnly:
+        // Cancelling the socket effect drops its trailing `await send(.gatewayClosed)`
+        // (TCA discards sends from a cancelled task), so no backoff reconnect is
+        // scheduled while suspended — `.foreground` owns the redial. Everything else
+        // (streaming fold pointers, thinking ticker, debounced persist) stays untouched:
+        // the state must survive intact for the foreground hydrate's #26 preservation of
+        // a still-running turn's live thinking/tool rows.
+        state.status = .reconnecting
+        state.hasRequestedSession = false
+        return .merge(
+          .cancel(id: CancelID.socket),
+          .cancel(id: CancelID.reconnect)
         )
 
       case .loadOlderRequested:

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -39,6 +39,12 @@ public struct ChatFeature {
     public var status: Status
     public var errorBanner: String?
     public var isSending: Bool
+    /// True while a turn is in flight — the same signal that powers the `runningChanged`
+    /// delegate (set on submit/`message.start`, cleared on complete/error/interrupt, and
+    /// reconciled from the authoritative `session.resume` `running` flag on hydrate).
+    /// The app-level slot policy reads this: a RUNNING chat keeps its slot (socket and
+    /// streaming effects) across a nav pop; an idle one is torn down.
+    public var isRunning: Bool { isSending }
     /// A blocking request from the agent (approval/clarify/secret). While set, the
     /// composer is disabled and a card is the focal point.
     public var pendingInteraction: PendingInteraction?
@@ -107,6 +113,12 @@ public struct ChatFeature {
     var toolRowIDs: [String: ChatRow.ID]
     var reconnectAttempt: Int
     var hasRequestedSession: Bool
+    /// Set by the first `.task` (the initial connect). The view's `.task` fires on EVERY
+    /// appearance — including re-appearing over a LIVE slot after a nav pop — and an
+    /// unconditional `connect` there would cancel-and-redial a healthy socket (the dial
+    /// gap drops streamed events). Once started, later appearances are routed by
+    /// `AppFeature` through `.reattached`, which guards the live socket.
+    var hasStarted: Bool
     /// Set when the gated session died (`.authExpired`): reconnect backoff is paused and the
     /// trailing `.gatewayClosed` (the finished stream) is ignored until re-auth resumes us.
     var awaitingReauth: Bool
@@ -150,6 +162,7 @@ public struct ChatFeature {
       self.toolRowIDs = [:]
       self.reconnectAttempt = 0
       self.hasRequestedSession = false
+      self.hasStarted = false
       self.awaitingReauth = false
       self.pendingInteraction = nil
       self.presentedTool = nil
@@ -235,7 +248,15 @@ public struct ChatFeature {
     case binding(BindingAction<State>)
     case delegate(Delegate)
     case task
-    case onDisappear
+    /// The chat VIEW left the screen. Releases view-session resources only (the mic /
+    /// voice recording) — the socket and streaming effects are owned by the app-level
+    /// live-chat slot and torn down separately via `.teardown` (an `AppFeature` policy).
+    case viewDisappeared
+    /// Full slot teardown (sent by `AppFeature`, never the view): cancel every
+    /// long-running effect — socket, reconnect backoff, voice, thinking ticker, debounced
+    /// persist — and release the mic. `AppFeature` flushes the snapshot (`.persistNow`)
+    /// before this where the pending debounce matters.
+    case teardown
     /// Scroll-up reached the top of the current window: reveal another `pageSize` of older
     /// rows from the in-memory transcript (client-side only — no network call).
     case loadOlderRequested
@@ -255,6 +276,13 @@ public struct ChatFeature {
     /// App returned to the foreground — reconnect the socket and re-`hydrate` (re-read
     /// running/inflight/usage) via the same unified path used by open/cold-launch.
     case foreground
+    /// The slot's marker was re-pushed over LIVE, surviving chat state (`AppFeature`'s
+    /// re-open policy): always re-hydrate (server authority; `applyActivate`'s #26 path
+    /// preserves a still-running turn's live thinking/tool rows), but do NOT
+    /// cancel-and-redial a healthy socket — the dial gap would drop streamed events.
+    /// Only a dead/dialing socket reconnects (then `.ready` re-hydrates, exactly like
+    /// `.foreground`).
+    case reattached
     case sessionResult(Result<SessionHandle, GatewayError>)
     /// Result of the `session.resume` hydration call — the server-authoritative
     /// re-hydration payload (messages + info + running + inflight). (The associated
@@ -360,9 +388,30 @@ public struct ChatFeature {
         // REST `loadHistory` call: the activate response carries `messages` + `info` +
         // `running` + `inflight`, and rebuilding the transcript wholesale from it is what
         // keeps model/usage/status correct on every re-open (the core state-sync fix).
+        //
+        // The view's `.task` fires on EVERY appearance — including re-appearing over a
+        // live slot after a nav pop. Only the slot's FIRST appearance performs the
+        // initial connect; re-opens are routed by `AppFeature` through `.reattached`,
+        // which must not cancel-and-redial a healthy socket.
+        guard !state.hasStarted else { return .none }
+        state.hasStarted = true
         return connect(state.connection)
 
-      case .onDisappear:
+      case .viewDisappeared:
+        // View-only cleanup: the screen left, but the slot (socket, streaming fold,
+        // thinking ticker, persist debounce) lives on — `AppFeature` decides teardown.
+        let wasRecording = state.recording.isBusy
+        state.recording = .idle
+        state.waveformLevels = []
+        state.recordingSeconds = 0
+        return .merge(
+          .cancel(id: CancelID.voiceLevels),
+          .cancel(id: CancelID.voiceTimer),
+          // Release the mic/session if we leave mid-recording.
+          wasRecording ? .run { [audioRecorder] _ in await audioRecorder.cancel() } : .none
+        )
+
+      case .teardown:
         let wasRecording = state.recording.isBusy
         state.recording = .idle
         state.waveformLevels = []
@@ -514,6 +563,27 @@ public struct ChatFeature {
         // `guard !state.hasRequestedSession` below, so foreground would never re-hydrate.
         state.hasRequestedSession = false
         return connect(state.connection)
+
+      case .reattached:
+        // Re-opening the live slot's session from the list (the state and socket
+        // survived the pop). A dead/dialing socket recovers exactly like `.foreground`:
+        // reset the hydrate guard and reconnect — the fresh `.ready` re-hydrates.
+        guard state.status == .ready else {
+          state.hasRequestedSession = false
+          return connect(state.connection)
+        }
+        // Socket healthy: hydrate directly against it — no reconnect, so the live socket
+        // keeps streaming throughout (no event gap). `applyActivate` is the same
+        // server-authoritative path as `.ready`, with the #26 preservation of a
+        // still-running turn's live thinking/tool rows.
+        guard let sessionID = state.storedSessionID ?? state.liveSessionID else {
+          // Connected but the session id hasn't resolved yet (`session.create` still in
+          // flight on this same socket) — nothing to hydrate; the pending result lands
+          // on its own.
+          return .none
+        }
+        state.hasRequestedSession = true
+        return hydrate(sessionID: sessionID, profile: state.scopedProfile)
 
       case .composerSubmitted:
         guard state.canSend, let sessionID = state.liveSessionID else { return .none }

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -108,6 +108,12 @@ public struct ChatFeature {
     // Bookkeeping (internal).
     var liveSessionID: String?
     var storedSessionID: String?
+    /// The stable key this chat's session is addressed by (`storedSessionID ??
+    /// liveSessionID`) — what the parent's slot routing (push-tap dedup, re-open compare,
+    /// archive matching, push suppression) and the snapshot/anchor store key on. `nil`
+    /// until a brand-new chat's `session.create` resolves. Public (read-only) so the app
+    /// target can mirror `fillLiveChat`'s marker construction (demo mode).
+    public var sessionKey: String? { storedSessionID ?? liveSessionID }
     var streamingRowID: ChatRow.ID?
     var thinkingRowID: ChatRow.ID?
     var toolRowIDs: [String: ChatRow.ID]
@@ -122,6 +128,12 @@ public struct ChatFeature {
     /// Set when the gated session died (`.authExpired`): reconnect backoff is paused and the
     /// trailing `.gatewayClosed` (the finished stream) is ignored until re-auth resumes us.
     var awaitingReauth: Bool
+    /// True while the single same-socket hydrate retry after a `.timedOut` failure is
+    /// outstanding. A timeout over a live-but-slow socket (huge history, busy gateway) is
+    /// indistinguishable from a HALF-OPEN one, so the first timeout retries `session.resume`
+    /// over the SAME socket; only a second consecutive timeout concludes half-open and
+    /// redials. Reset on hydrate success and at every fresh hydrate issuance.
+    var hydrateRetriedAfterTimeout: Bool
 
     public enum Status: Equatable, Sendable {
       case connecting
@@ -164,6 +176,7 @@ public struct ChatFeature {
       self.hasRequestedSession = false
       self.hasStarted = false
       self.awaitingReauth = false
+      self.hydrateRetriedAfterTimeout = false
       self.pendingInteraction = nil
       self.presentedTool = nil
       self.model = nil
@@ -227,6 +240,12 @@ public struct ChatFeature {
       return hasContent
         && liveSessionID != nil
         && pendingInteraction == nil
+        // The visible send button becomes the interrupt button mid-turn, but a hardware-
+        // keyboard return still fires the TextField's `.onSubmit` — a second submit while a
+        // turn streams must be a no-op (it would corrupt `isSending` and, if it later
+        // failed, emit a spurious `runningChanged(false)` that tears down a detached slot
+        // whose first turn is still genuinely running).
+        && !isSending
     }
 
     /// Rename is only meaningful once we have a live session id (otherwise `confirmRename`
@@ -248,9 +267,11 @@ public struct ChatFeature {
     case binding(BindingAction<State>)
     case delegate(Delegate)
     case task
-    /// The chat VIEW left the screen. Releases view-session resources only (the mic /
-    /// voice recording) — the socket and streaming effects are owned by the app-level
-    /// live-chat slot and torn down separately via `.teardown` (an `AppFeature` policy).
+    /// The chat VIEW left the screen (forwarded by `AppFeature.chatViewDisappeared`, which
+    /// guards a nil slot — the view never sends into this scope directly). Releases
+    /// view-session resources only (the mic / voice recording) — the socket and streaming
+    /// effects are owned by the app-level live-chat slot and torn down separately via
+    /// `.teardown` (an `AppFeature` policy).
     case viewDisappeared
     /// Full slot teardown (sent by `AppFeature`, never the view): cancel every
     /// long-running effect — socket, reconnect backoff, voice, thinking ticker, debounced
@@ -281,15 +302,18 @@ public struct ChatFeature {
     /// (cancel the pending debounce, write now) and reaffirm the turn-start anchor while a
     /// turn is in flight, so a process kill doesn't lose the latest paint or timer anchor.
     case persistNow
-    /// App returned to the foreground — reconnect the socket and re-`hydrate` (re-read
-    /// running/inflight/usage) via the same unified path used by open/cold-launch.
+    /// App returned to the foreground — re-`hydrate` (re-read running/inflight/usage) via
+    /// the same unified path used by open/cold-launch, reconnecting the socket only if it
+    /// isn't `.ready` (a socket the background grace window kept alive must NOT be
+    /// cancel-and-redialed — the dial gap would drop streamed events). Shares its handler
+    /// with `.reattached`.
     case foreground
     /// The slot's marker was re-pushed over LIVE, surviving chat state (`AppFeature`'s
     /// re-open policy): always re-hydrate (server authority; `applyActivate`'s #26 path
     /// preserves a still-running turn's live thinking/tool rows), but do NOT
     /// cancel-and-redial a healthy socket — the dial gap would drop streamed events.
-    /// Only a dead/dialing socket reconnects (then `.ready` re-hydrates, exactly like
-    /// `.foreground`).
+    /// Only a dead/dialing socket reconnects (then `.ready` re-hydrates). Shares its
+    /// handler with `.foreground`.
     case reattached
     case sessionResult(Result<SessionHandle, GatewayError>)
     /// Result of the `session.resume` hydration call — the server-authoritative
@@ -360,7 +384,9 @@ public struct ChatFeature {
     }
   }
 
-  private enum CancelID { case socket, reconnect, copyFeedback, voiceLevels, voiceTimer, thinkingTimer, persist }
+  private enum CancelID {
+    case socket, reconnect, hydrate, copyFeedback, voiceLevels, voiceTimer, thinkingTimer, persist
+  }
 
   /// Debounce window for write-back so heavy streaming doesn't thrash SQLite.
   private static let persistDebounce: Duration = .seconds(1)
@@ -408,31 +434,16 @@ public struct ChatFeature {
       case .viewDisappeared:
         // View-only cleanup: the screen left, but the slot (socket, streaming fold,
         // thinking ticker, persist debounce) lives on — `AppFeature` decides teardown.
-        let wasRecording = state.recording.isBusy
-        state.recording = .idle
-        state.waveformLevels = []
-        state.recordingSeconds = 0
-        return .merge(
-          .cancel(id: CancelID.voiceLevels),
-          .cancel(id: CancelID.voiceTimer),
-          // Release the mic/session if we leave mid-recording.
-          wasRecording ? .run { [audioRecorder] _ in await audioRecorder.cancel() } : .none
-        )
+        return releaseVoiceResources(&state)
 
       case .teardown:
-        let wasRecording = state.recording.isBusy
-        state.recording = .idle
-        state.waveformLevels = []
-        state.recordingSeconds = 0
         return .merge(
+          releaseVoiceResources(&state),
           .cancel(id: CancelID.socket),
           .cancel(id: CancelID.reconnect),
-          .cancel(id: CancelID.voiceLevels),
-          .cancel(id: CancelID.voiceTimer),
+          .cancel(id: CancelID.hydrate),
           .cancel(id: CancelID.thinkingTimer),
-          .cancel(id: CancelID.persist),
-          // Release the mic/session if we leave mid-recording.
-          wasRecording ? .run { [audioRecorder] _ in await audioRecorder.cancel() } : .none
+          .cancel(id: CancelID.persist)
         )
 
       case .teardownSocketOnly:
@@ -442,11 +453,17 @@ public struct ChatFeature {
         // (streaming fold pointers, thinking ticker, debounced persist) stays untouched:
         // the state must survive intact for the foreground hydrate's #26 preservation of
         // a still-running turn's live thinking/tool rows.
+        //
+        // Also cancel any pending hydrate: socket cancellation resumes its RPC with
+        // `.disconnected`, and a stale `.activateResult` reducing AFTER this deliberate
+        // teardown could otherwise act on a socket we just chose to drop (e.g. redial
+        // while backgrounded after grace expiry, wasting a single-use ws-ticket).
         state.status = .reconnecting
         state.hasRequestedSession = false
         return .merge(
           .cancel(id: CancelID.socket),
-          .cancel(id: CancelID.reconnect)
+          .cancel(id: CancelID.reconnect),
+          .cancel(id: CancelID.hydrate)
         )
 
       case .loadOlderRequested:
@@ -549,12 +566,48 @@ public struct ChatFeature {
         }
         // Offline / connection error: keep the cached instant-paint on screen (never blank
         // it) and show a subtle reconnecting status. The cached rows stay until a successful
-        // resume replaces them wholesale. A plain `.disconnected` (the socket dropped — e.g.
-        // lock/unlock) is already conveyed by the `.reconnecting` status, so we do NOT raise a
-        // banner for it (it would otherwise linger after reconnect); only a real protocol/server
-        // error gets a banner.
+        // resume replaces them wholesale.
         state.status = .reconnecting
-        if !error.isDisconnected { state.errorBanner = error.message }
+        // `.disconnected` is never the lone symptom: the connection teardown that resumed
+        // this RPC with `.disconnected` also finishes the event stream, so a companion
+        // `.gatewayClosed` — with its escalating backoff — follows on its own. Redialing
+        // here would defeat that backoff (a crash-looping server that drops on
+        // `session.resume` would reconnect in a zero-delay storm) and would be actively
+        // wrong when the socket effect was deliberately cancelled. Status-only; banner-less
+        // (a banner would linger past the reconnect).
+        if error.isDisconnected { return .none }
+        // The hydrate RPC `.timedOut` over a stale-`.ready` socket after suspension/NAT
+        // rebind: a HALF-OPEN socket may not surface `.gatewayClosed` for minutes, so we
+        // must schedule the redial OURSELVES rather than strand the chat in `.reconnecting`
+        // with no reconnect pending. Two guards keep this from killing a healthy socket:
+        // - during the re-auth pause do nothing (a redial would waste a single-use
+        //   ws-ticket; `.resumeAfterReauth` owns the reconnect), and
+        // - a timeout over a live-but-SLOW socket (huge history, busy gateway) is
+        //   indistinguishable from half-open, so the first timeout retries the hydrate once
+        //   over the SAME socket instead of killing a possibly-streaming connection; only a
+        //   second consecutive timeout concludes half-open and redials. (Trade-off: a truly
+        //   half-open socket takes two request timeouts before the redial — accepted, since
+        //   repeatedly killing a demonstrably-alive streaming socket mid-turn is worse.)
+        // `connect` is cancellable on `CancelID.socket` with `cancelInFlight: true`, so a
+        // concurrent `.gatewayClosed` backoff dial is safe (last dial wins); cancel any
+        // pending backoff tick so it can't later redial over the fresh socket. Reset
+        // `hasRequestedSession` so the fresh `.ready` actually re-hydrates. Banner-less —
+        // a timeout is a transport symptom, not a server verdict; only a real
+        // protocol/server error gets a banner.
+        if error.isTimedOut {
+          guard !state.awaitingReauth else { return .none }
+          if !state.hydrateRetriedAfterTimeout, let sessionID = state.sessionKey {
+            state.hydrateRetriedAfterTimeout = true
+            return hydrate(sessionID: sessionID, profile: state.scopedProfile)
+          }
+          state.hydrateRetriedAfterTimeout = false
+          state.hasRequestedSession = false
+          return .merge(
+            .cancel(id: CancelID.reconnect),
+            connect(state.connection)
+          )
+        }
+        state.errorBanner = error.message
         return .none
 
       case .persistSnapshotTick:
@@ -572,39 +625,36 @@ public struct ChatFeature {
           anchor
         )
 
-      case .foreground:
-        // App returned to the foreground: reconnect + re-`hydrate` via the same socket path
-        // used on open. A live socket is torn down on `.onDisappear`/background, so reconnect
-        // re-fires `.ready` → `hydrate`, re-reading the authoritative running/inflight/usage.
-        //
-        // Reset `hasRequestedSession` so the fresh `.ready` actually re-hydrates. On a fast
-        // background→foreground the prior socket may still be alive; `connect`'s
-        // `cancelInFlight` then cancels it mid-`for await`, and TCA drops the cancelled
-        // task's trailing `await send(.gatewayClosed)` — the only place that resets the flag.
-        // Without this reset the flag stays `true` and the new `.ready` short-circuits at the
-        // `guard !state.hasRequestedSession` below, so foreground would never re-hydrate.
-        state.hasRequestedSession = false
-        return connect(state.connection)
-
-      case .reattached:
-        // Re-opening the live slot's session from the list (the state and socket
-        // survived the pop). A dead/dialing socket recovers exactly like `.foreground`:
-        // reset the hydrate guard and reconnect — the fresh `.ready` re-hydrates.
+      case .foreground, .reattached:
+        // Two re-attach entry points, one policy: the app returned to the foreground, or
+        // the slot's marker was re-pushed over live, surviving chat state. Always
+        // re-hydrate (server authority), but NEVER cancel-and-redial a HEALTHY socket —
+        // the dial gap drops streamed events, and within the background grace window the
+        // socket kept streaming precisely so foreground would not have to redial it.
         guard state.status == .ready else {
+          // Dead/dialing socket (including after a grace-expiry `.teardownSocketOnly`):
+          // reconnect — the fresh `.ready` re-hydrates. Reset `hasRequestedSession` so
+          // that ready actually hydrates: on a fast background→foreground the prior
+          // socket is cancelled mid-`for await`, and TCA drops the cancelled task's
+          // trailing `await send(.gatewayClosed)` — the only other place that resets
+          // the flag.
           state.hasRequestedSession = false
           return connect(state.connection)
         }
         // Socket healthy: hydrate directly against it — no reconnect, so the live socket
-        // keeps streaming throughout (no event gap). `applyActivate` is the same
+        // keeps streaming throughout (no event gap). A socket that silently died while
+        // suspended still self-heals: the hydrate RPC fails, the receive loop finishes →
+        // `.gatewayClosed` → backoff reconnect. `applyActivate` is the same
         // server-authoritative path as `.ready`, with the #26 preservation of a
         // still-running turn's live thinking/tool rows.
-        guard let sessionID = state.storedSessionID ?? state.liveSessionID else {
+        guard let sessionID = state.sessionKey else {
           // Connected but the session id hasn't resolved yet (`session.create` still in
           // flight on this same socket) — nothing to hydrate; the pending result lands
           // on its own.
           return .none
         }
         state.hasRequestedSession = true
+        state.hydrateRetriedAfterTimeout = false // fresh hydrate: the retry budget resets
         return hydrate(sessionID: sessionID, profile: state.scopedProfile)
 
       case .composerSubmitted:
@@ -706,7 +756,12 @@ public struct ChatFeature {
         // `setTurnAnchor` paired with a clear, so anchors can't accumulate for sessions that
         // never produce a snapshot row (those aren't counted by the LRU sweep, which only
         // evicts `sessions` rows).
-        return clearTurnAnchor(state)
+        // This is also a CLIENT-SIDE turn end — no server event will ever follow — so emit
+        // `runningChanged(false)` like `.messageComplete`/`.error` do: a DETACHED slot kept
+        // alive only while running would otherwise leak forever (`AppFeature`'s teardown
+        // policy keys off this delegate). Harmless to the list glow (it only lights on
+        // `message.start`).
+        return .merge(clearTurnAnchor(state), runningChanged(false, state))
 
       case let .liveSessionIDRefreshed(liveSessionID, storedSessionID):
         // Self-heal landed a fresh runtime id (#17). Swap it in so subsequent RPCs target the
@@ -982,8 +1037,9 @@ public struct ChatFeature {
         for index in state.attachments.indices { state.attachments[index].uploadState = .failed(message) }
         // The attachment-submit path wrote the turn anchor; a failed upload never starts a
         // turn, so clear it — keeping every `setTurnAnchor` paired with a clear (mirrors
-        // `.promptSubmitFailed`).
-        return clearTurnAnchor(state)
+        // `.promptSubmitFailed`). Client-side turn end: also emit `runningChanged(false)` so
+        // a DETACHED slot waiting on the turn is torn down (no server event will follow).
+        return .merge(clearTurnAnchor(state), runningChanged(false, state))
 
       case .attachmentsUnsupportedDetected:
         // The agent is too old to accept uploads: hide the affordance for the session and
@@ -992,7 +1048,10 @@ public struct ChatFeature {
         state.isSending = false
         state.errorBanner = "This Hermes agent is too old to accept attachments. Update the agent to send files."
         for index in state.attachments.indices { state.attachments[index].uploadState = .failed("Attachments not supported") }
-        return .none
+        // Client-side turn end (the submit was aborted; no server event will follow): emit
+        // `runningChanged(false)` so a DETACHED slot waiting on the turn is torn down
+        // (mirrors `.promptSubmitFailed` / `.attachmentUploadFailed`).
+        return runningChanged(false, state)
 
       case let .toolTapped(id):
         guard let row = state.transcript[id: id], case .tool = row.kind else { return .none }
@@ -1115,6 +1174,7 @@ public struct ChatFeature {
       // No stored id → a fresh session: `session.create` (handle only). A stored id →
       // re-hydrate server-authoritatively via the unified `hydrate` path.
       if let stored = state.storedSessionID {
+        state.hydrateRetriedAfterTimeout = false // fresh hydrate: the retry budget resets
         return hydrate(sessionID: stored, profile: state.scopedProfile)
       }
       return createSession(profile: state.scopedProfile)
@@ -1299,6 +1359,21 @@ public struct ChatFeature {
     state.isSending = false
   }
 
+  /// Shared voice cleanup for `.viewDisappeared` and `.teardown`: reset the recording UI
+  /// state, cancel the level/tick effects, and release the mic/session if we leave
+  /// mid-recording.
+  private func releaseVoiceResources(_ state: inout State) -> Effect<Action> {
+    let wasRecording = state.recording.isBusy
+    state.recording = .idle
+    state.waveformLevels = []
+    state.recordingSeconds = 0
+    return .merge(
+      .cancel(id: CancelID.voiceLevels),
+      .cancel(id: CancelID.voiceTimer),
+      wasRecording ? .run { [audioRecorder] _ in await audioRecorder.cancel() } : .none
+    )
+  }
+
   /// 1s `continuousClock` loop that drives the live "Thinking" elapsed timer. Mirrors the
   /// voice-recording tick. Cancel any prior loop first so a fresh turn starts at 0.
   private func startThinkingTimer() -> Effect<Action> {
@@ -1458,6 +1533,11 @@ public struct ChatFeature {
         await send(.activateResult(.failure(.disconnected)))
       }
     }
+    // Only one hydrate may be outstanding, and a DELIBERATE socket teardown
+    // (`.teardownSocketOnly` / `.teardown`) cancels it so no stale `.activateResult`
+    // reduces afterwards (the socket cancellation would otherwise resume this RPC with
+    // `.disconnected`, e.g. redialing while backgrounded after grace expiry).
+    .cancellable(id: CancelID.hydrate, cancelInFlight: true)
   }
 
   /// Apply a server-authoritative `ActivateResponse` into state: bind the live/stored ids,
@@ -1470,6 +1550,7 @@ public struct ChatFeature {
     state.liveSessionID = response.sessionID
     state.storedSessionID = response.storedSessionID ?? state.storedSessionID
     state.status = .ready
+    state.hydrateRetriedAfterTimeout = false // hydrate landed: the timeout-retry budget resets
     // A successful hydrate means we're connected — clear any stale connection banner.
     state.errorBanner = nil
 
@@ -1701,7 +1782,7 @@ public struct ChatFeature {
   /// store can't persist them even if we passed them through) — they can't be re-hydrated from
   /// the server and base64 blobs would bloat the cache.
   private func persistSnapshotNow(_ state: State) -> Effect<Action> {
-    guard let sessionID = state.storedSessionID ?? state.liveSessionID else { return .none }
+    guard let sessionID = state.sessionKey else { return .none }
     let snapshot = ChatSnapshot(
       model: state.model,
       reasoningEffort: state.reasoningEffort,
@@ -1720,7 +1801,7 @@ public struct ChatFeature {
   /// (`storedSessionID ?? liveSessionID`) so the anchor written on submit is read back by
   /// `hydrate` (which keys on the stored id) on the next open.
   private func anchorKey(_ state: State) -> String? {
-    state.storedSessionID ?? state.liveSessionID
+    state.sessionKey
   }
 
   /// Emit `delegate(.runningChanged)` for the session list so the row's working glow

--- a/HermesKit/Sources/HermesKit/Features/ChatScreen.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatScreen.swift
@@ -1,0 +1,27 @@
+import ComposableArchitecture
+
+/// A thin navigation marker for a pushed chat screen. The REAL chat state lives in
+/// `AppFeature.State.liveChat` (the app-owned "live chat slot"), so a running turn's
+/// socket and streaming effects survive navigation pops — the path holds only this
+/// session-key marker and carries no behavior of its own.
+@Reducer
+public struct ChatScreen {
+  @ObservableState
+  public struct State: Equatable {
+    /// The session key this marker points at (`storedSessionID ?? liveSessionID` at push
+    /// time). `nil` for a brand-new chat whose id hasn't resolved yet.
+    public var sessionKey: String?
+
+    public init(sessionKey: String? = nil) {
+      self.sessionKey = sessionKey
+    }
+  }
+
+  public enum Action: Equatable, Sendable {}
+
+  public init() {}
+
+  public var body: some ReducerOf<Self> {
+    EmptyReducer()
+  }
+}

--- a/HermesKit/Sources/HermesKit/Features/ChatScreen.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatScreen.swift
@@ -9,7 +9,10 @@ public struct ChatScreen {
   @ObservableState
   public struct State: Equatable {
     /// The session key this marker points at (`storedSessionID ?? liveSessionID` at push
-    /// time). `nil` for a brand-new chat whose id hasn't resolved yet.
+    /// time). `nil` for a brand-new chat whose id hasn't resolved yet — and NOT updated
+    /// when it does. Diagnostic/test-observability only: production routing always derives
+    /// the on-screen session from the slot (`AppFeature.State.currentViewingSessionID`),
+    /// never from this marker.
     public var sessionKey: String?
 
     public init(sessionKey: String? = nil) {

--- a/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
@@ -430,6 +430,10 @@ public struct SessionListFeature {
       /// but NOT sent — used by the push "Ask agent to install" flow so the user reviews + sends.
       case createSession(initialComposerText: String?)
       case disconnect
+      /// The user confirmed archiving this session (the optimistic removal + PATCH follow).
+      /// Emitted FIRST so the parent can tear the live-chat slot down when it matches — a
+      /// detached slot's socket must not keep streaming into a now-archived session.
+      case sessionArchived(id: Session.ID)
     }
   }
 
@@ -769,20 +773,26 @@ public struct SessionListFeature {
         // Cancel any in-flight fetch (list load OR search) too: one started before this
         // archive could land afterward and resurrect the row we just optimistically removed.
         let archiveProfile = state.scopedProfileName
-        return .merge(
-          .cancel(id: CancelID.fetch),
-          .run { [rest, preferences, connection = state.connection] send in
-            preferences.savePinnedIDs(pinnedIDs)
-            preferences.saveSeenCounts(seenCounts)
-            do {
-              try await rest.archive(connection, id, true, archiveProfile)
-              await send(.archiveSucceeded(id: id))
-            } catch {
-              await send(.archiveFailed(
-                id: id, session: session, index: index, pinIndex: pinIndex, seenCount: seenCount
-              ))
+        return .concatenate(
+          // Tell the parent FIRST (before the PATCH runs) so it can tear the live-chat slot
+          // down when this is the slot's session — the (possibly detached) socket must not
+          // keep streaming into a now-archived session.
+          .send(.delegate(.sessionArchived(id: id))),
+          .merge(
+            .cancel(id: CancelID.fetch),
+            .run { [rest, preferences, connection = state.connection] send in
+              preferences.savePinnedIDs(pinnedIDs)
+              preferences.saveSeenCounts(seenCounts)
+              do {
+                try await rest.archive(connection, id, true, archiveProfile)
+                await send(.archiveSucceeded(id: id))
+              } catch {
+                await send(.archiveFailed(
+                  id: id, session: session, index: index, pinIndex: pinIndex, seenCount: seenCount
+                ))
+              }
             }
-          }
+          )
         )
 
       case let .confirmationDialog(.presented(.confirmDeleteProfile(name))):

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -106,7 +106,7 @@ struct AppFeatureTests {
     }
   }
 
-  @Test func openingSessionPushesChat() async {
+  @Test func openingSessionFillsSlotAndPushesMarker() async {
     let store = TestStore(
       initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
     ) {
@@ -115,19 +115,19 @@ struct AppFeatureTests {
     let session = Session(id: "20260610_abc", title: "Protocol chat")
 
     await store.send(.home(.delegate(.openSession(session)))) {
-      $0.path.append(
-        ChatFeature.State(
-          connection: self.connection,
-          resumeStoredID: "20260610_abc",
-          // Default profile → unscoped (nil), so the chat is byte-identical to single-profile.
-          profileName: nil,
-          title: "Protocol chat"
-        )
+      // The chat state fills the app-level live slot; the path only gets a thin marker.
+      $0.liveChat = ChatFeature.State(
+        connection: self.connection,
+        resumeStoredID: "20260610_abc",
+        // Default profile → unscoped (nil), so the chat is byte-identical to single-profile.
+        profileName: nil,
+        title: "Protocol chat"
       )
+      $0.path.append(ChatScreen.State(sessionKey: "20260610_abc"))
     }
   }
 
-  @Test func creatingSessionPushesNewChat() async {
+  @Test func creatingSessionFillsSlotWithNewChat() async {
     let store = TestStore(
       initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
     ) {
@@ -135,9 +135,9 @@ struct AppFeatureTests {
     }
 
     await store.send(.home(.delegate(.createSession(initialComposerText: nil)))) {
-      $0.path.append(
-        ChatFeature.State(connection: self.connection, profileName: nil, composerText: "")
-      )
+      $0.liveChat = ChatFeature.State(connection: self.connection, profileName: nil, composerText: "")
+      // A brand-new chat has no session key yet — the marker resolves later.
+      $0.path.append(ChatScreen.State(sessionKey: nil))
     }
   }
 
@@ -149,11 +149,10 @@ struct AppFeatureTests {
     }
 
     await store.send(.home(.delegate(.createSession(initialComposerText: PushSetup.installPrompt)))) {
-      $0.path.append(
-        ChatFeature.State(
-          connection: self.connection, profileName: nil, composerText: PushSetup.installPrompt
-        )
+      $0.liveChat = ChatFeature.State(
+        connection: self.connection, profileName: nil, composerText: PushSetup.installPrompt
       )
+      $0.path.append(ChatScreen.State(sessionKey: nil))
     }
   }
 
@@ -170,14 +169,13 @@ struct AppFeatureTests {
     let session = Session(id: "20260610_abc", title: "Protocol chat")
 
     await store.send(.home(.delegate(.openSession(session)))) {
-      $0.path.append(
-        ChatFeature.State(
-          connection: self.connection,
-          resumeStoredID: "20260610_abc",
-          profileName: "work",
-          title: "Protocol chat"
-        )
+      $0.liveChat = ChatFeature.State(
+        connection: self.connection,
+        resumeStoredID: "20260610_abc",
+        profileName: "work",
+        title: "Protocol chat"
       )
+      $0.path.append(ChatScreen.State(sessionKey: "20260610_abc"))
     }
   }
 
@@ -193,10 +191,305 @@ struct AppFeatureTests {
     }
 
     await store.send(.home(.delegate(.createSession(initialComposerText: nil)))) {
-      $0.path.append(
-        ChatFeature.State(connection: self.connection, profileName: "work", composerText: "")
+      $0.liveChat = ChatFeature.State(connection: self.connection, profileName: "work", composerText: "")
+      $0.path.append(ChatScreen.State(sessionKey: nil))
+    }
+  }
+
+  // MARK: - Live chat slot lifecycle (keep-alive plan, Tasks 1–2)
+
+  /// Popping back to the list with an IDLE chat tears the slot down (nothing to keep
+  /// alive): flush the snapshot, cancel everything, clear the slot.
+  @Test func popTearsDownAndClearsSlot() async {
+    let store = TestStore(
+      initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      // The pop flushes the snapshot (`.persistNow`), which stamps `updatedAt`.
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+    let session = Session(id: "s1", title: "Chat")
+
+    await store.send(.home(.delegate(.openSession(session))))
+    #expect(store.state.liveChat != nil)
+
+    await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+    #expect(store.state.path.isEmpty)
+  }
+
+  /// Opening a different session while the slot is occupied flushes the old chat's snapshot
+  /// and tears it down FIRST (its socket must not leak into the replacement), then fills the
+  /// slot + resets the marker.
+  @Test func openingAnotherSessionReplacesSlotAfterTeardown() async {
+    let snapshotClient = ChatSnapshotClient.inMemory()
+    var liveChat = ChatFeature.State(connection: connection, resumeStoredID: "old")
+    liveChat.liveSessionID = "old-live"
+    liveChat.model = "claude-opus-4-8"
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "old")]),
+        liveChat: liveChat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.chatSnapshot = snapshotClient
+      $0.date = .constant(Date(timeIntervalSince1970: 55))
+    }
+    store.exhaustivity = .off
+
+    await store.send(.home(.delegate(.openSession(Session(id: "new", title: "New chat")))))
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.fillLiveChat) {
+      $0.liveChat = ChatFeature.State(
+        connection: self.connection, resumeStoredID: "new", profileName: nil, title: "New chat"
       )
     }
+    #expect(store.state.path.count == 1)
+    #expect(store.state.path.last?.sessionKey == "new")
+    // The outgoing chat's snapshot was flushed before the replacement filled the slot.
+    #expect(snapshotClient.loadSnapshot("old")?.model == "claude-opus-4-8")
+  }
+
+  /// Logout (disconnect from Settings) clears the slot unconditionally along with the path.
+  @Test func disconnectClearsLiveChatSlot() async {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: ChatFeature.State(connection: connection, resumeStoredID: "s1")
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.home(.delegate(.disconnect))) {
+      $0.home = nil
+      $0.liveChat = nil
+      $0.path = .init()
+    }
+    await store.finish()
+  }
+
+  /// Popping mid-turn KEEPS the slot untouched — no persist/teardown/clear fires (the send
+  /// is exhaustive: any follow-up action would fail it), and the detached slot's fold still
+  /// reduces streaming events, so rows keep accumulating while the user sits on the list.
+  @Test func popWhileRunningKeepsSlotAndKeepsStreaming() async {
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+    }
+
+    // Exhaustive: the pop only empties the path — the running slot is untouched.
+    await store.send(.path(.popFrom(id: store.state.path.ids.last!))) {
+      $0.path = StackState()
+    }
+    #expect(store.state.liveChat != nil)
+
+    // A streaming delta arriving after the pop still mutates the detached slot's transcript
+    // (the socket fold is slot-rooted, not screen-rooted).
+    let rowID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+    await store.send(.liveChat(.gatewayEvent(.messageDelta(text: "still streaming")))) {
+      $0.liveChat?.transcript.append(ChatRow(
+        id: rowID, kind: .message(role: .assistant, text: "still streaming", isComplete: false)
+      ))
+      $0.liveChat?.streamingRowID = rowID
+    }
+    // The delta's debounced persist is still pending — living proof the slot's effects
+    // survived the pop. Cancel it via an explicit app-policy teardown at test end.
+    await store.send(.liveChat(.teardown))
+  }
+
+  /// A detached slot (user popped to the list) is torn down the moment its turn ends — the
+  /// authoritative `runningChanged(running: false)` (message.complete / error / a hydrate
+  /// confirming stopped) flushes the snapshot, cancels the effects, and clears the slot.
+  /// A `running: true` change must NOT tear anything down.
+  @Test func turnEndingWhileDetachedTearsDownSlot() async {
+    let snapshotClient = ChatSnapshotClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+    chat.model = "claude-opus-4-8"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection, sessions: [Session(id: "s1", isActive: true)]
+        ),
+        // Empty path — the chat streams detached.
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.chatSnapshot = snapshotClient
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    // Still running → glow routing only; the detached slot stays.
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: true))))
+    await store.receive(\.home.setSessionRunning)
+    #expect(store.state.liveChat != nil)
+
+    // Turn ended while detached → glow clears, then flush + teardown + clear.
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: false))))
+    await store.receive(\.home.setSessionRunning) {
+      $0.home?.sessions[id: "s1"]?.isActive = false
+    }
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+    // The snapshot flush landed before the slot cleared.
+    #expect(snapshotClient.loadSnapshot("s1")?.model == "claude-opus-4-8")
+  }
+
+  /// Archiving the slot's session from the list tears the (detached) slot down FIRST — its
+  /// socket must not keep streaming into a now-archived session. Archiving a DIFFERENT
+  /// session leaves the slot alone.
+  @Test func archivingSlotSessionTearsDownSlot() async {
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection, sessions: [Session(id: "s1"), Session(id: "other")]
+        ),
+        // Empty path — the user is on the list (where archive lives).
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences = .inMemory()
+      $0.hermesREST.archive = { @Sendable _, _, _, _ in }
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    // Archiving an unrelated session: the slot survives.
+    await store.send(.home(.archiveButtonTapped(id: "other")))
+    await store.send(.home(.confirmationDialog(.presented(.confirmArchive(id: "other")))))
+    await store.receive(\.home.delegate.sessionArchived)
+    await store.skipReceivedActions()
+    #expect(store.state.liveChat != nil)
+
+    // Archiving the slot's session: flush + teardown + clear.
+    await store.send(.home(.archiveButtonTapped(id: "s1")))
+    await store.send(.home(.confirmationDialog(.presented(.confirmArchive(id: "s1")))))
+    await store.receive(\.home.delegate.sessionArchived)
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+  }
+
+  /// Re-opening the slot's OWN session from the list (tapping the glowing row of a detached
+  /// running turn) must NOT build a fresh `ChatFeature.State` — the accumulated detached
+  /// rows and composer draft survive. The marker is pushed back and `.reattached` hydrates
+  /// against the live socket without redialing it.
+  @Test func reopeningSlotSessionReattachesKeepingDetachedRows() async {
+    let connectCalls = LockIsolated(0)
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.status = .ready
+    chat.hasRequestedSession = true
+    chat.hasStarted = true
+    chat.isSending = true
+    chat.composerText = "unsent draft"
+    // Rows accumulated while detached: the live thinking row the server's payload can't
+    // rebuild (#26) — a re-init would lose it.
+    let thinkingID = UUID(uuidString: "00000000-0000-0000-0000-00000000AAAA")!
+    chat.transcript = [
+      ChatRow(id: thinkingID, kind: .thinking(
+        reasoning: "detached reasoning", status: nil, elapsedSeconds: 3, isComplete: false
+      ))
+    ]
+    chat.thinkingRowID = thinkingID
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        // Empty path — the user popped to the list; the slot streams detached.
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+      $0.hermesGateway.send = { @Sendable method, _ in
+        // The hydrate may fan out a follow-up (e.g. `session.usage`) — only the resume
+        // payload matters here.
+        guard method == "session.resume" else { return .object([:]) }
+        return .object([
+          "session_id": .string("live1"),
+          "stored_session_id": .string("s1"),
+          "messages": .array([
+            .object(["id": .number(1), "role": .string("user"), "content": .string("the question")]),
+          ]),
+          "running": .bool(true),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.home(.delegate(.openSession(Session(id: "s1")))))
+    // Marker re-pushed; the slot state itself was NOT re-inited (draft survives).
+    #expect(store.state.path.count == 1)
+    #expect(store.state.path.last?.sessionKey == "s1")
+    #expect(store.state.liveChat?.composerText == "unsent draft")
+
+    await store.receive(\.liveChat.reattached)
+    await store.receive(\.liveChat.activateResult.success)
+
+    // The healthy socket was never redialed, the hydrate landed, and the detached live
+    // thinking row survived the server-authoritative rebuild (#26 preservation).
+    #expect(connectCalls.value == 0)
+    #expect(store.state.liveChat?.model == "claude-opus-4-8")
+    #expect(store.state.liveChat?.composerText == "unsent draft")
+    #expect(store.state.liveChat?.transcript.contains { row in
+      if case let .thinking(reasoning, _, _, isComplete) = row.kind {
+        return reasoning == "detached reasoning" && !isComplete
+      }
+      return false
+    } == true)
+
+    await store.send(.liveChat(.teardown))
   }
 
   // MARK: - Re-auth routing (Task 6)
@@ -224,19 +517,43 @@ struct AppFeatureTests {
   }
 
   @Test func sessionExpiredPresentsReauthModalSeededFromChat() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: cookieConnection))
-    let id = path.ids.last!
     let store = TestStore(
       initialState: AppFeature.State(
-        home: SessionListFeature.State(connection: cookieConnection), path: path
+        home: SessionListFeature.State(connection: cookieConnection),
+        path: StackState([ChatScreen.State()]),
+        liveChat: ChatFeature.State(connection: cookieConnection)
       )
     ) {
       AppFeature()
     }
     store.exhaustivity = .off
 
-    await store.send(.path(.element(id: id, action: .delegate(.sessionExpired)))) {
+    await store.send(.liveChat(.delegate(.sessionExpired))) {
+      $0.reauth = ReauthFeature.State(
+        serverURL: URL(string: "http://mac.tailnet:9119")!,
+        method: .password,
+        provider: "basic",
+        previousUsername: "alice"
+      )
+    }
+  }
+
+  /// The slot chat can be DETACHED (user popped to the list) when the session dies — the
+  /// re-auth modal must still surface at root (locked decision: reauth surfaces at root
+  /// even while detached).
+  @Test func sessionExpiredWhileDetachedStillPresentsReauthModal() async {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: cookieConnection),
+        // Empty path — the chat lives only in the slot.
+        liveChat: ChatFeature.State(connection: cookieConnection)
+      )
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.liveChat(.delegate(.sessionExpired))) {
       $0.reauth = ReauthFeature.State(
         serverURL: URL(string: "http://mac.tailnet:9119")!,
         method: .password,
@@ -247,14 +564,12 @@ struct AppFeatureTests {
   }
 
   @Test func sameUserReauthResumesChatInPlace() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: cookieConnection))
-    let id = path.ids.last!
     let fresh = freshCookieConnection(username: "alice")
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: cookieConnection),
-        path: path,
+        path: StackState([ChatScreen.State()]),
+        liveChat: ChatFeature.State(connection: cookieConnection),
         reauth: ReauthFeature.State(
           serverURL: URL(string: "http://mac.tailnet:9119")!, method: .password,
           provider: "basic", previousUsername: "alice"
@@ -264,7 +579,7 @@ struct AppFeatureTests {
       AppFeature()
     } withDependencies: {
       // A never-finishing socket so the resume's `connect` effect stays alive (no trailing
-      // `gatewayClosed`/reconnect churn); we cancel it via `onDisappear` at the end.
+      // `gatewayClosed`/reconnect churn); we cancel it via `.teardown` at the end.
       $0.hermesGateway.connect = { @Sendable _, _ in AsyncStream { _ in } }
     }
     store.exhaustivity = .off
@@ -272,19 +587,17 @@ struct AppFeatureTests {
     await store.send(.reauth(.presented(.delegate(.reauthenticated(connection: fresh, sameUser: true))))) {
       $0.reauth = nil
     }
-    // Same user → the dead chat is told to resume with the fresh connection (stays in place).
-    await store.receive(\.path) {
-      $0.path[id: id]?.connection = fresh
-      $0.path[id: id]?.awaitingReauth = false
-      $0.path[id: id]?.status = .reconnecting
+    // Same user → the slot chat is told to resume with the fresh connection (stays in place).
+    await store.receive(\.liveChat.resumeAfterReauth) {
+      $0.liveChat?.connection = fresh
+      $0.liveChat?.awaitingReauth = false
+      $0.liveChat?.status = .reconnecting
     }
     // Tear down the live socket the resume opened.
-    await store.send(.path(.element(id: id, action: .onDisappear)))
+    await store.send(.liveChat(.teardown))
   }
 
   @Test func differentUserReauthPopsToListAndClearsIdentityPrefs() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: cookieConnection))
     let fresh = freshCookieConnection(username: "bob")
     let pinsCleared = LockIsolated(false)
     let seenCleared = LockIsolated(false)
@@ -292,7 +605,8 @@ struct AppFeatureTests {
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: cookieConnection),
-        path: path,
+        path: StackState([ChatScreen.State()]),
+        liveChat: ChatFeature.State(connection: cookieConnection),
         reauth: ReauthFeature.State(
           serverURL: URL(string: "http://mac.tailnet:9119")!, method: .password,
           provider: "basic", previousUsername: "alice"
@@ -310,6 +624,7 @@ struct AppFeatureTests {
     await store.send(.reauth(.presented(.delegate(.reauthenticated(connection: fresh, sameUser: false))))) {
       $0.reauth = nil
       $0.path = .init()
+      $0.liveChat = nil
       $0.home = SessionListFeature.State(connection: fresh)
     }
     #expect(pinsCleared.value)
@@ -318,14 +633,13 @@ struct AppFeatureTests {
   }
 
   @Test func quitFromReauthFullyLogsOutToOnboarding() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: cookieConnection))
     let sessionDeleted = LockIsolated(false)
     let urlCleared = LockIsolated(false)
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: cookieConnection),
-        path: path,
+        path: StackState([ChatScreen.State()]),
+        liveChat: ChatFeature.State(connection: cookieConnection),
         reauth: ReauthFeature.State(
           serverURL: URL(string: "http://mac.tailnet:9119")!, method: .password,
           provider: "basic", previousUsername: "alice"
@@ -342,6 +656,7 @@ struct AppFeatureTests {
     await store.send(.reauth(.presented(.delegate(.quit)))) {
       $0.reauth = nil
       $0.path = .init()
+      $0.liveChat = nil
       $0.home = nil
       $0.onboarding = .init()
     }
@@ -374,19 +689,18 @@ struct AppFeatureTests {
   }
 
   @Test func tokenSessionExpiredSeedsTokenReauthModal() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: connection)) // `.token` connection
-    let id = path.ids.last!
     let store = TestStore(
       initialState: AppFeature.State(
-        home: SessionListFeature.State(connection: connection), path: path
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State()]),
+        liveChat: ChatFeature.State(connection: connection) // `.token` connection
       )
     ) {
       AppFeature()
     }
     store.exhaustivity = .off
 
-    await store.send(.path(.element(id: id, action: .delegate(.sessionExpired)))) {
+    await store.send(.liveChat(.delegate(.sessionExpired))) {
       $0.reauth = ReauthFeature.State(
         serverURL: URL(string: "http://mac.tailnet:9119")!, method: .token
       )
@@ -407,40 +721,37 @@ struct AppFeatureTests {
     }
 
     await store.send(.home(.delegate(.createSession(initialComposerText: nil)))) {
-      $0.path.append(
-        ChatFeature.State(connection: self.connection, profileName: nil, composerText: "")
-      )
+      $0.liveChat = ChatFeature.State(connection: self.connection, profileName: nil, composerText: "")
+      $0.path.append(ChatScreen.State(sessionKey: nil))
     }
   }
 
   // MARK: Event-driven working glow routing (Task 7)
 
-  // The open chat's `runningChanged` delegate is routed to the session list, which patches the
+  // The live chat's `runningChanged` delegate is routed to the session list, which patches the
   // row's working flag (glow) INSTANTLY — no poll required.
   @Test func chatRunningChangedRoutesToSessionListGlow() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: connection, resumeStoredID: "s1"))
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(
           connection: connection,
           sessions: [Session(id: "s1", isActive: true)]
         ),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: ChatFeature.State(connection: connection, resumeStoredID: "s1")
       )
     ) {
       AppFeature()
     }
-    let id = store.state.path.ids[0]
 
-    // A finished turn in the open chat → clear the row glow immediately.
-    await store.send(.path(.element(id: id, action: .delegate(.runningChanged(sessionID: "s1", running: false)))))
+    // A finished turn in the live chat → clear the row glow immediately.
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: false))))
     await store.receive(\.home.setSessionRunning) {
       $0.home?.sessions[id: "s1"]?.isActive = false
     }
 
     // A started turn → light it again.
-    await store.send(.path(.element(id: id, action: .delegate(.runningChanged(sessionID: "s1", running: true)))))
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: true))))
     await store.receive(\.home.setSessionRunning) {
       $0.home?.sessions[id: "s1"]?.isActive = true
     }
@@ -461,13 +772,11 @@ struct AppFeatureTests {
 
     // Opening the session paints the chat from cache (no server contact yet). The session list
     // row starts NOT active.
-    var path = StackState<ChatFeature.State>()
     let painted = withDependencies {
       $0.chatSnapshot = snapshotClient
     } operation: {
       ChatFeature.State(connection: connection, resumeStoredID: "s1")
     }
-    path.append(painted)
 
     let store = TestStore(
       initialState: AppFeature.State(
@@ -475,7 +784,8 @@ struct AppFeatureTests {
           connection: connection,
           sessions: [Session(id: "s1", isActive: false)]
         ),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: painted
       )
     ) {
       AppFeature()
@@ -490,17 +800,16 @@ struct AppFeatureTests {
 
   // MARK: App lifecycle — scenePhase (Task 8)
 
-  // `.active` (foreground) fans out: the open chat reconnects + re-activates (`.foreground`),
+  // `.active` (foreground) fans out: the live chat reconnects + re-activates (`.foreground`),
   // and the session list refreshes immediately (`.pulledToRefresh`) — no waiting for the poll.
   // The thin view scenePhase wiring isn't unit-tested; this `scenePhaseChanged` action is the
   // covered behaviour.
   @Test func foregroundReconnectsOpenChatAndRefreshesList() async {
-    var path = StackState<ChatFeature.State>()
-    path.append(ChatFeature.State(connection: connection, resumeStoredID: "s1"))
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: ChatFeature.State(connection: connection, resumeStoredID: "s1")
       )
     ) {
       AppFeature()
@@ -513,15 +822,14 @@ struct AppFeatureTests {
       $0.date = .constant(Date(timeIntervalSince1970: 0))
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
-    let id = store.state.path.ids[0]
 
     await store.send(.scenePhaseChanged(.active))
-    // Open chat told to reconnect + re-activate.
-    await store.receive(\.path[id: id].foreground)
+    // Live chat told to reconnect + re-activate.
+    await store.receive(\.liveChat.foreground)
     // List refreshed immediately.
     await store.receive(\.home.pulledToRefresh)
 
-    await store.send(.path(.element(id: id, action: .onDisappear)))
+    await store.send(.liveChat(.teardown))
     await store.send(.home(.onDisappear))
   }
 
@@ -547,7 +855,7 @@ struct AppFeatureTests {
     await store.send(.home(.onDisappear))
   }
 
-  // `.background` routes `.persistNow` to the open chat, which flushes its snapshot + anchor to
+  // `.background` routes `.persistNow` to the live chat, which flushes its snapshot + anchor to
   // the cache immediately (verified end-to-end via the in-memory snapshot store below).
   @Test func backgroundRoutesPersistNowToOpenChat() async {
     let snapshotClient = ChatSnapshotClient.inMemory()
@@ -555,13 +863,12 @@ struct AppFeatureTests {
     chat.storedSessionID = "s1"
     chat.liveSessionID = "live1"
     chat.model = "claude-opus-4-8"
-    var path = StackState<ChatFeature.State>()
-    path.append(chat)
 
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
       )
     ) {
       AppFeature()
@@ -570,10 +877,9 @@ struct AppFeatureTests {
       $0.date = .constant(Date(timeIntervalSince1970: 999))
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
-    let id = store.state.path.ids[0]
 
     await store.send(.scenePhaseChanged(.background))
-    await store.receive(\.path[id: id].persistNow)
+    await store.receive(\.liveChat.persistNow)
 
     // Snapshot was written synchronously (not waiting for the debounce).
     let saved = snapshotClient.loadSnapshot("s1")
@@ -589,13 +895,12 @@ struct AppFeatureTests {
     chat.storedSessionID = "s1"
     chat.liveSessionID = "live1"
     chat.isSending = true
-    var path = StackState<ChatFeature.State>()
-    path.append(chat)
 
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
       )
     ) {
       AppFeature()
@@ -604,12 +909,11 @@ struct AppFeatureTests {
       $0.date = .constant(Date(timeIntervalSince1970: 4242))
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
-    let id = store.state.path.ids[0]
 
     #expect(snapshotClient.turnAnchor("s1") == nil)
 
     await store.send(.scenePhaseChanged(.background))
-    await store.receive(\.path[id: id].persistNow)
+    await store.receive(\.liveChat.persistNow)
 
     // Anchor written at the current date.
     #expect(snapshotClient.turnAnchor("s1") == Date(timeIntervalSince1970: 4242))
@@ -621,13 +925,12 @@ struct AppFeatureTests {
     var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
     chat.storedSessionID = "s1"
     chat.liveSessionID = "live1"
-    var path = StackState<ChatFeature.State>()
-    path.append(chat)
 
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: connection),
-        path: path
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
       )
     ) {
       AppFeature()
@@ -636,10 +939,9 @@ struct AppFeatureTests {
       $0.date = .constant(Date(timeIntervalSince1970: 7))
     }
     store.exhaustivity = .off(showSkippedAssertions: false)
-    let id = store.state.path.ids[0]
 
     await store.send(.scenePhaseChanged(.inactive))
-    await store.receive(\.path[id: id].persistNow)
+    await store.receive(\.liveChat.persistNow)
 
     #expect(snapshotClient.loadSnapshot("s1")?.updatedAt == Date(timeIntervalSince1970: 7))
   }
@@ -662,7 +964,8 @@ struct AppFeatureTests {
 
     await store.send(.pushTapped(PushTap(sessionID: "20260620_xyz")))
     await store.receive(\.home.delegate.openSession)
-    #expect(store.state.path.last?.storedSessionID == "20260620_xyz")
+    #expect(store.state.liveChat?.storedSessionID == "20260620_xyz")
+    #expect(store.state.path.last?.sessionKey == "20260620_xyz")
     // The reducer marked the now-open session as currently-viewing (foreground suppression).
     #expect(push.currentSession == "20260620_xyz")
   }
@@ -687,7 +990,8 @@ struct AppFeatureTests {
     push.emit(tap: PushTap(sessionID: "from-stream"))
     await store.receive(\.pushTapped)
     await store.receive(\.home.delegate.openSession)
-    #expect(store.state.path.last?.storedSessionID == "from-stream")
+    #expect(store.state.liveChat?.storedSessionID == "from-stream")
+    #expect(store.state.path.last?.sessionKey == "from-stream")
     // The tap observer is a long-running effect on the in-memory stream — drop it at teardown.
     await store.skipInFlightEffects()
   }
@@ -702,6 +1006,8 @@ struct AppFeatureTests {
       AppFeature()
     } withDependencies: {
       $0.push = push.client
+      // The pop flushes the snapshot (`.persistNow`), which stamps `updatedAt`.
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
     }
     store.exhaustivity = .off
     let session = Session(id: "20260610_abc", title: "Chat")
@@ -710,10 +1016,15 @@ struct AppFeatureTests {
     await store.finish()
     #expect(push.currentSession == "20260610_abc")
 
-    // Pop the chat (path empties) → current-viewing marker cleared.
+    // Pop the chat (path empties) → current-viewing marker cleared (and, for now, the
+    // slot is torn down unconditionally — Task 2 adds the keep-while-running policy).
     await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    // Drain the pop's follow-up actions (persistNow → teardown → clearLiveChat) so the
+    // asserted state reflects the completed teardown.
+    await store.skipReceivedActions()
     await store.finish()
     #expect(push.currentSession == nil)
+    #expect(store.state.liveChat == nil)
   }
 
   /// An approval tap with no session list yet (can't open) bumps the pending-approval badge;

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -289,6 +289,7 @@ struct AppFeatureTests {
     chat.liveSessionID = "live1"
     chat.isSending = true
 
+    let clock = TestClock()
     let store = TestStore(
       initialState: AppFeature.State(
         home: SessionListFeature.State(connection: connection),
@@ -299,8 +300,21 @@ struct AppFeatureTests {
       AppFeature()
     } withDependencies: {
       $0.uuid = .incrementing
-      $0.continuousClock = TestClock()
+      $0.continuousClock = clock
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
     }
+
+    // The turn's live thinking row + elapsed ticker start before the pop.
+    let thinkingID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
+    await store.send(.liveChat(.gatewayEvent(.messageStart))) {
+      $0.liveChat?.transcript = [ChatRow(
+        id: thinkingID, kind: .thinking(reasoning: "", status: nil, elapsedSeconds: 0, isComplete: false)
+      )]
+      $0.liveChat?.thinkingRowID = thinkingID
+    }
+    await store.receive(\.liveChat.delegate.runningChanged)
+    await store.receive(\.home.setSessionRunning)
 
     // Exhaustive: the pop only empties the path — the running slot is untouched.
     await store.send(.path(.popFrom(id: store.state.path.ids.last!))) {
@@ -308,18 +322,130 @@ struct AppFeatureTests {
     }
     #expect(store.state.liveChat != nil)
 
-    // A streaming delta arriving after the pop still mutates the detached slot's transcript
-    // (the socket fold is slot-rooted, not screen-rooted).
-    let rowID = UUID(uuidString: "00000000-0000-0000-0000-000000000000")!
-    await store.send(.liveChat(.gatewayEvent(.messageDelta(text: "still streaming")))) {
-      $0.liveChat?.transcript.append(ChatRow(
-        id: rowID, kind: .message(role: .assistant, text: "still streaming", isComplete: false)
-      ))
-      $0.liveChat?.streamingRowID = rowID
+    // The elapsed ticker keeps ticking while detached — the timer is continuous across the
+    // pop (no freeze, no restart from zero on re-open). The 1s advance also fires the
+    // debounced snapshot persist `messageStart`'s content change scheduled (same 1s window)
+    // — both effects living on after the pop is exactly the point.
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.liveChat.persistSnapshotTick)
+    await store.receive(\.liveChat.thinkingTick) {
+      $0.liveChat?.thinkingSeconds = 1
     }
-    // The delta's debounced persist is still pending — living proof the slot's effects
-    // survived the pop. Cancel it via an explicit app-policy teardown at test end.
+
+    // A streaming delta arriving after the pop still mutates the detached slot's transcript
+    // (the socket fold is slot-rooted, not screen-rooted) — the thinking row is not lost.
+    let assistantID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+    await store.send(.liveChat(.gatewayEvent(.messageDelta(text: "still streaming")))) {
+      $0.liveChat?.transcript = [
+        ChatRow(id: assistantID, kind: .message(role: .assistant, text: "still streaming", isComplete: false)),
+        ChatRow(id: thinkingID, kind: .thinking(reasoning: "", status: nil, elapsedSeconds: 0, isComplete: false)),
+      ]
+      $0.liveChat?.streamingRowID = assistantID
+    }
+    // The delta's debounced persist + the live ticker are still pending — living proof the
+    // slot's effects survived the pop. Cancel them via an explicit app-policy teardown.
     await store.send(.liveChat(.teardown))
+  }
+
+  /// Socket-leak guard (Task 7 acceptance): the idle-pop teardown path cancels the socket
+  /// effect (`CancelID.socket`) exactly once — one dial, one stream termination, nothing
+  /// left running and nothing double-cancelled. The gateway client is instrumented to count
+  /// connects and terminations.
+  @Test func idlePopCancelsSocketExactlyOnce() async {
+    let connectCount = LockIsolated(0)
+    let cancelCount = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: ChatFeature.State(connection: connection, resumeStoredID: "s1")
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCount.withValue { $0 += 1 }
+        return AsyncStream { continuation in
+          continuation.onTermination = { _ in cancelCount.withValue { $0 += 1 } }
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // First appearance dials exactly one socket.
+    await store.send(.liveChat(.task))
+    while connectCount.value == 0 { await Task.yield() }
+    #expect(connectCount.value == 1)
+    #expect(cancelCount.value == 0)
+
+    // The idle pop's teardown terminates that one stream (a leak would hang this wait).
+    await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+    while cancelCount.value == 0 { await Task.yield() }
+    #expect(cancelCount.value == 1)
+    // The teardown never redialed.
+    #expect(connectCount.value == 1)
+  }
+
+  /// Socket-leak guard (Task 7 acceptance): replacing the slot cancels the OLD chat's socket
+  /// exactly once BEFORE the replacement dials its own — asserted before the new `.task` so
+  /// the fresh connect's `cancelInFlight` can't mask a missing teardown. The new socket then
+  /// stays alive until its own teardown.
+  @Test func slotReplacementCancelsOldSocketExactlyOnce() async {
+    let connectCount = LockIsolated(0)
+    let cancelCount = LockIsolated(0)
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "old")]),
+        liveChat: ChatFeature.State(connection: connection, resumeStoredID: "old")
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCount.withValue { $0 += 1 }
+        return AsyncStream { continuation in
+          continuation.onTermination = { _ in cancelCount.withValue { $0 += 1 } }
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.liveChat(.task))
+    while connectCount.value == 0 { await Task.yield() }
+
+    // Opening a different session tears the old slot down first: its socket terminates
+    // exactly once, before any replacement dial.
+    await store.send(.home(.delegate(.openSession(Session(id: "new")))))
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.fillLiveChat)
+    while cancelCount.value == 0 { await Task.yield() }
+    #expect(cancelCount.value == 1)
+    #expect(connectCount.value == 1)
+
+    // The replacement dials its own fresh stream; the count proves the old cancel didn't
+    // hit the new socket (position-scoped cancel IDs would otherwise cross-cancel).
+    await store.send(.liveChat(.task))
+    while connectCount.value == 1 { await Task.yield() }
+    #expect(connectCount.value == 2)
+    #expect(cancelCount.value == 1)
+
+    // And the new socket's own teardown is the second (and last) termination.
+    await store.send(.liveChat(.teardown))
+    while cancelCount.value == 1 { await Task.yield() }
+    #expect(cancelCount.value == 2)
   }
 
   /// A detached slot (user popped to the list) is torn down the moment its turn ends — the

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -199,7 +199,9 @@ struct AppFeatureTests {
   // MARK: - Live chat slot lifecycle (keep-alive plan, Tasks 1–2)
 
   /// Popping back to the list with an IDLE chat tears the slot down (nothing to keep
-  /// alive): flush the snapshot, cancel everything, clear the slot.
+  /// alive): flush the snapshot, cancel everything, clear the slot. The teardown is
+  /// deferred to `.chatViewDisappeared` (the view actually left — pop animation done);
+  /// `.popFrom` itself does nothing so the outgoing screen never blanks mid-animation.
   @Test func popTearsDownAndClearsSlot() async {
     let store = TestStore(
       initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
@@ -215,7 +217,13 @@ struct AppFeatureTests {
     await store.send(.home(.delegate(.openSession(session))))
     #expect(store.state.liveChat != nil)
 
+    // Pop-start: path empties, slot untouched (the screen is still animating away).
     await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    #expect(store.state.liveChat != nil)
+
+    // The view finished disappearing → mic cleanup + the idle teardown sequence.
+    await store.send(.chatViewDisappeared)
+    await store.receive(\.liveChat.viewDisappeared)
     await store.receive(\.liveChat.persistNow)
     await store.receive(\.liveChat.teardown)
     await store.receive(\.clearLiveChat) {
@@ -249,6 +257,11 @@ struct AppFeatureTests {
     await store.send(.home(.delegate(.openSession(Session(id: "new", title: "New chat")))))
     await store.receive(\.liveChat.persistNow)
     await store.receive(\.liveChat.teardown)
+    // The replacement routes through the nil-out: `ifLet` cancels the outgoing chat's
+    // remaining (un-ID'd one-shot) effects before the new chat fills the slot.
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
     await store.receive(\.fillLiveChat) {
       $0.liveChat = ChatFeature.State(
         connection: self.connection, resumeStoredID: "new", profileName: nil, title: "New chat"
@@ -322,6 +335,13 @@ struct AppFeatureTests {
     }
     #expect(store.state.liveChat != nil)
 
+    // The view finishing its pop animation (what the destination actually sends) forwards
+    // mic/voice cleanup only — a RUNNING detached slot is still not torn down (exhaustive:
+    // any teardown follow-up would fail here).
+    await store.send(.chatViewDisappeared)
+    await store.receive(\.liveChat.viewDisappeared)
+    #expect(store.state.liveChat != nil)
+
     // The elapsed ticker keeps ticking while detached — the timer is continuous across the
     // pop (no freeze, no restart from zero on re-open). The 1s advance also fires the
     // debounced snapshot persist `messageStart`'s content change scheduled (same 1s window)
@@ -377,19 +397,20 @@ struct AppFeatureTests {
 
     // First appearance dials exactly one socket.
     await store.send(.liveChat(.task))
-    while connectCount.value == 0 { await Task.yield() }
-    #expect(connectCount.value == 1)
+    await waitUntil { connectCount.value == 1 }
     #expect(cancelCount.value == 0)
 
-    // The idle pop's teardown terminates that one stream (a leak would hang this wait).
+    // The idle pop's teardown (deferred until the view disappeared) terminates that one
+    // stream (a leak would fail the bounded wait).
     await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    await store.send(.chatViewDisappeared)
+    await store.receive(\.liveChat.viewDisappeared)
     await store.receive(\.liveChat.persistNow)
     await store.receive(\.liveChat.teardown)
     await store.receive(\.clearLiveChat) {
       $0.liveChat = nil
     }
-    while cancelCount.value == 0 { await Task.yield() }
-    #expect(cancelCount.value == 1)
+    await waitUntil { cancelCount.value == 1 }
     // The teardown never redialed.
     #expect(connectCount.value == 1)
   }
@@ -423,29 +444,86 @@ struct AppFeatureTests {
     store.exhaustivity = .off(showSkippedAssertions: false)
 
     await store.send(.liveChat(.task))
-    while connectCount.value == 0 { await Task.yield() }
+    await waitUntil { connectCount.value == 1 }
 
-    // Opening a different session tears the old slot down first: its socket terminates
-    // exactly once, before any replacement dial.
+    // Opening a different session tears the old slot down first (through the nil-out, so
+    // even un-ID'd one-shot effects are cancelled): its socket terminates exactly once,
+    // before any replacement dial.
     await store.send(.home(.delegate(.openSession(Session(id: "new")))))
     await store.receive(\.liveChat.persistNow)
     await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat)
     await store.receive(\.fillLiveChat)
-    while cancelCount.value == 0 { await Task.yield() }
-    #expect(cancelCount.value == 1)
+    await waitUntil { cancelCount.value == 1 }
     #expect(connectCount.value == 1)
 
     // The replacement dials its own fresh stream; the count proves the old cancel didn't
     // hit the new socket (position-scoped cancel IDs would otherwise cross-cancel).
     await store.send(.liveChat(.task))
-    while connectCount.value == 1 { await Task.yield() }
-    #expect(connectCount.value == 2)
+    await waitUntil { connectCount.value == 2 }
     #expect(cancelCount.value == 1)
 
     // And the new socket's own teardown is the second (and last) termination.
     await store.send(.liveChat(.teardown))
-    while cancelCount.value == 1 { await Task.yield() }
-    #expect(cancelCount.value == 2)
+    await waitUntil { cancelCount.value == 2 }
+  }
+
+  /// Replacement leak guard: an in-flight ONE-SHOT RPC effect of the outgoing chat (here a
+  /// `session.resume` hydrate — one-shots carry NO cancel ID, so `.teardown` alone can't
+  /// reach them) must be cancelled by the replacement's nil-out (`.clearLiveChat` →
+  /// `ifLet` auto-cancel). Were it leaked, its `.activateResult` would reduce into the
+  /// REPLACEMENT chat — overwriting the new chat's session ids and rebuilding its
+  /// transcript from the OLD session's history.
+  @Test func slotReplacementDropsInFlightHydrateOfOldChat() async {
+    let clock = TestClock()
+    var oldChat = ChatFeature.State(connection: connection, resumeStoredID: "old")
+    oldChat.status = .ready
+    oldChat.hasStarted = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "old")]),
+        liveChat: oldChat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = clock
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.send = { @Sendable method, _ in
+        guard method == "session.resume" else { return .object([:]) }
+        // A slow resume: still in flight when the slot is replaced.
+        try await clock.sleep(for: .seconds(5))
+        return .object([
+          "session_id": .string("old-live"),
+          "stored_session_id": .string("old"),
+          "messages": .array([
+            .object(["id": .number(1), "role": .string("user"), "content": .string("old history")]),
+          ]),
+          "running": .bool(false),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Kick off the old chat's hydrate (healthy socket → direct hydrate, no redial).
+    await store.send(.liveChat(.reattached))
+
+    // Replace the slot while that hydrate is still in flight.
+    await store.send(.home(.delegate(.openSession(Session(id: "new", title: "New chat")))))
+    await store.receive(\.fillLiveChat)
+    #expect(store.state.liveChat?.storedSessionID == "new")
+
+    // Let the old RPC's clock fire: its task was cancelled by the nil-out, so NO
+    // `.activateResult` may deliver into the replacement chat.
+    await clock.advance(by: .seconds(5))
+    await store.finish()
+    #expect(store.state.liveChat?.storedSessionID == "new")
+    #expect(store.state.liveChat?.liveSessionID == nil) // the old live id never leaked in
+    #expect(store.state.liveChat?.transcript.isEmpty == true) // nor the old history
   }
 
   /// A detached slot (user popped to the list) is torn down the moment its turn ends — the
@@ -494,6 +572,79 @@ struct AppFeatureTests {
     #expect(snapshotClient.loadSnapshot("s1")?.model == "claude-opus-4-8")
   }
 
+  /// A CLIENT-SIDE turn end must also tear a detached slot down: the submit RPC failing
+  /// (e.g. a 30s timeout after the user already popped to the list) means NO server event
+  /// will ever follow — without `promptSubmitFailed` emitting `runningChanged(false)`, the
+  /// idle detached chat would keep its socket, backoff, and persist effects forever.
+  @Test func promptFailureWhileDetachedTearsDownSlot() async {
+    let snapshotClient = ChatSnapshotClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+    chat.model = "claude-opus-4-8"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection, sessions: [Session(id: "s1", isActive: true)]
+        ),
+        // Empty path — the user popped while the submit RPC was still in flight.
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.chatSnapshot = snapshotClient
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    // The submit fails after the pop: client-side turn end → glow clears, slot torn down.
+    await store.send(.liveChat(.promptSubmitFailed(message: "request timed out: prompt.submit")))
+    await store.receive(\.liveChat.delegate.runningChanged)
+    await store.receive(\.home.setSessionRunning) {
+      $0.home?.sessions[id: "s1"]?.isActive = false
+    }
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+    // The snapshot flush landed before the slot cleared.
+    #expect(snapshotClient.loadSnapshot("s1")?.model == "claude-opus-4-8")
+  }
+
+  /// Same client-side turn end via the attachment path: a failed upload (no server event
+  /// will follow) must tear a detached slot down like `promptSubmitFailed` does.
+  @Test func attachmentFailureWhileDetachedTearsDownSlot() async {
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection, sessions: [Session(id: "s1", isActive: true)]
+        ),
+        liveChat: chat // empty path — detached
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    await store.send(.liveChat(.attachmentUploadFailed(message: "boom")))
+    await store.receive(\.liveChat.delegate.runningChanged)
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat) {
+      $0.liveChat = nil
+    }
+  }
+
   /// Archiving the slot's session from the list tears the (detached) slot down FIRST — its
   /// socket must not keep streaming into a now-archived session. Archiving a DIFFERENT
   /// session leaves the slot alone.
@@ -535,6 +686,42 @@ struct AppFeatureTests {
     await store.receive(\.clearLiveChat) {
       $0.liveChat = nil
     }
+  }
+
+  /// Archive of the slot's session whose PATCH then FAILS: the list restores the row
+  /// locally (optimistic rollback), but the slot deliberately STAYS torn down — the
+  /// teardown ran on the optimistic `sessionArchived` delegate, and resurrecting live
+  /// slot state for a rare failure path isn't worth replaying it; re-opening simply
+  /// resumes the session fresh. This pins that accepted behavior.
+  @Test func archiveFailureRestoresRowButSlotStaysDown() async {
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        // Empty path — the user is on the list (where archive lives).
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences = .inMemory()
+      $0.hermesREST.archive = { @Sendable _, _, _, _ in throw RESTError.unreachable }
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    await store.send(.home(.archiveButtonTapped(id: "s1")))
+    await store.send(.home(.confirmationDialog(.presented(.confirmArchive(id: "s1")))))
+    // Optimistic: the slot is torn down FIRST (before the PATCH round-trips)…
+    await store.receive(\.home.delegate.sessionArchived)
+    await store.receive(\.clearLiveChat)
+    // …then the PATCH fails and the row is restored — but the slot stays down.
+    await store.receive(\.home.archiveFailed)
+    #expect(store.state.home?.sessions[id: "s1"] != nil)
+    #expect(store.state.liveChat == nil)
   }
 
   /// Re-opening the slot's OWN session from the list (tapping the glowing row of a detached
@@ -1045,12 +1232,17 @@ struct AppFeatureTests {
     #expect(snapshotClient.turnAnchor("s1") == Date(timeIntervalSince1970: 4242))
   }
 
-  // `.inactive` is treated like background (immediate flush) — no foreground reconnect.
+  // `.inactive` is a flush only — no foreground reconnect, and (unlike `.background`) NO
+  // grace task even mid-turn: a transient occlusion (app switcher, notification shade)
+  // isn't suspension.
   @Test func inactiveFlushesSnapshot() async {
+    let background = BackgroundTaskClient.inMemory()
     let snapshotClient = ChatSnapshotClient.inMemory()
     var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
     chat.storedSessionID = "s1"
     chat.liveSessionID = "live1"
+    // A RUNNING turn — the strongest case: even this must not begin a background task.
+    chat.isSending = true
 
     let store = TestStore(
       initialState: AppFeature.State(
@@ -1061,15 +1253,17 @@ struct AppFeatureTests {
     ) {
       AppFeature()
     } withDependencies: {
+      $0.backgroundTask = background.client
       $0.chatSnapshot = snapshotClient
       $0.date = .constant(Date(timeIntervalSince1970: 7))
     }
-    store.exhaustivity = .off(showSkippedAssertions: false)
 
+    // Exhaustive: the flush is the only follow-up — no grace listener effect.
     await store.send(.scenePhaseChanged(.inactive))
     await store.receive(\.liveChat.persistNow)
 
     #expect(snapshotClient.loadSnapshot("s1")?.updatedAt == Date(timeIntervalSince1970: 7))
+    #expect(background.beginCount == 0)
   }
 
   // MARK: Background grace window (Task 5)
@@ -1116,7 +1310,7 @@ struct AppFeatureTests {
     await store.receive(\.liveChat.persistNow)
 
     // The grace task was begun...
-    while background.beginCount == 0 { await Task.yield() }
+    await waitUntil { background.beginCount == 1 }
     #expect(background.activeTaskName == "hermes.chat.background-grace")
     // ...and the socket is untouched: a streaming delta still reduces into the slot.
     #expect(socketClosed.value == false)
@@ -1176,7 +1370,7 @@ struct AppFeatureTests {
     await store.send(.liveChat(.task))
     await store.send(.scenePhaseChanged(.background))
     await store.receive(\.liveChat.persistNow)
-    while background.beginCount == 0 { await Task.yield() }
+    await waitUntil { background.beginCount == 1 }
 
     // iOS expires the window while still backgrounded.
     background.expire()
@@ -1187,8 +1381,9 @@ struct AppFeatureTests {
     }
 
     // The socket effect was cancelled (stream terminated) with no `.gatewayClosed` backoff,
-    // the task was ended, and the chat state survived in memory.
-    while !socketClosed.value { await Task.yield() }
+    // the task was ended — by the CLIENT's mandatory expiry bookkeeping (the reducer sends
+    // no `end()` of its own on expiry) — and the chat state survived in memory.
+    await waitUntil { socketClosed.value }
     #expect(background.endCount == 1)
     #expect(background.activeTaskName == nil)
     #expect(store.state.liveChat != nil)
@@ -1231,14 +1426,14 @@ struct AppFeatureTests {
 
     await store.send(.scenePhaseChanged(.background))
     await store.receive(\.liveChat.persistNow)
-    while background.beginCount == 0 { await Task.yield() }
+    await waitUntil { background.beginCount == 1 }
 
     await store.send(.scenePhaseChanged(.active))
     await store.receive(\.liveChat.foreground)
     await store.receive(\.home.pulledToRefresh)
 
     // Task ended by `.active`; a stale expiry can no longer fire (nothing active).
-    while background.endCount == 0 { await Task.yield() }
+    await waitUntil { background.endCount == 1 }
     #expect(background.activeTaskName == nil)
     background.expire()
     #expect(background.endCount == 1)
@@ -1250,7 +1445,8 @@ struct AppFeatureTests {
   }
 
   /// `.background` with an IDLE chat flushes only — no background task is begun (nothing to
-  /// keep alive, no battery burn).
+  /// keep alive, no battery burn). Exhaustive: the flush is the ONLY follow-up, and a
+  /// leaked grace listener (a long-running effect) would fail the store's effect check.
   @Test func backgroundWhileIdleStartsNoGraceTask() async {
     let background = BackgroundTaskClient.inMemory()
     var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
@@ -1269,15 +1465,16 @@ struct AppFeatureTests {
       $0.chatSnapshot = .inMemory()
       $0.date = .constant(Date(timeIntervalSince1970: 0))
     }
-    store.exhaustivity = .off(showSkippedAssertions: false)
 
-    await store.send(.scenePhaseChanged(.background))
+    await store.send(.scenePhaseChanged(.background)) {
+      $0.isSceneBackgrounded = true
+    }
     await store.receive(\.liveChat.persistNow)
     #expect(background.beginCount == 0)
   }
 
-  /// `.background` with no slot at all is a no-op (exhaustive: no state change, no effects —
-  /// in particular no background task).
+  /// `.background` with no slot at all only records the scene phase (exhaustive: no
+  /// effects — in particular no background task).
   @Test func backgroundWithNoSlotIsNoOp() async {
     let background = BackgroundTaskClient.inMemory()
     let store = TestStore(
@@ -1288,8 +1485,118 @@ struct AppFeatureTests {
       $0.backgroundTask = background.client
     }
 
-    await store.send(.scenePhaseChanged(.background))
+    await store.send(.scenePhaseChanged(.background)) {
+      $0.isSceneBackgrounded = true
+    }
     #expect(background.beginCount == 0)
+  }
+
+  /// A stray `.backgroundGraceExpired` racing `.active` (its send escaped the listener just
+  /// before the cancel landed) must be a strict no-op: `.active` already ran `.foreground`,
+  /// and a late `teardownSocketOnly` would kill the socket with no reconnect scheduled —
+  /// stranding the chat in `.reconnecting` until the next foreground.
+  @Test func staleGraceExpiryAfterActiveIsNoOp() async {
+    let background = BackgroundTaskClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in AsyncStream { _ in } }
+      $0.hermesREST.sessions = { @Sendable _, _, _, _ in [] }
+      $0.hermesREST.cronJobs = { @Sendable _, _ in throw RESTError.notFound }
+      $0.hermesProfiles.list = { @Sendable _ in throw RESTError.notFound }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+    await waitUntil { background.beginCount == 1 }
+
+    // Return to the foreground: the socket redials via `.foreground`.
+    await store.send(.scenePhaseChanged(.active))
+    await store.receive(\.liveChat.foreground)
+    await store.receive(\.home.pulledToRefresh)
+
+    // The raced expiry delivers AFTER `.active` — the scene-phase guard drops it: no
+    // socket-only teardown (the status never flips to `.reconnecting`).
+    await store.send(.backgroundGraceExpired)
+    #expect(store.state.liveChat?.status != .reconnecting)
+
+    await store.send(.liveChat(.teardown))
+    await store.send(.home(.onDisappear))
+  }
+
+  /// `.backgroundGraceExpired` with no slot left (e.g. the detached turn already ended and
+  /// tore it down) is a strict no-op — nothing to flush or disconnect.
+  @Test func graceExpiryWithNoSlotIsNoOp() async {
+    let store = TestStore(
+      initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
+    ) {
+      AppFeature()
+    }
+
+    await store.send(.scenePhaseChanged(.background)) {
+      $0.isSceneBackgrounded = true
+    }
+    // Exhaustive: no `.liveChat` sends, no effects.
+    await store.send(.backgroundGraceExpired)
+  }
+
+  /// A DETACHED turn ending during the grace window tears the slot down AND releases the
+  /// background task early — nothing is left for the OS window to keep alive, so the app
+  /// shouldn't stay awake for the rest of it. The cancelled listener also means a later
+  /// OS expiry can never deliver `.backgroundGraceExpired` into the empty slot.
+  @Test func detachedTurnEndDuringGraceReleasesTaskEarly() async {
+    let background = BackgroundTaskClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection, sessions: [Session(id: "s1", isActive: true)]
+        ),
+        // Empty path — the turn streams detached while backgrounded.
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+    await waitUntil { background.beginCount == 1 }
+
+    // The turn completes while detached + backgrounded → teardown + early task release.
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: false))))
+    await store.receive(\.clearLiveChat)
+    await waitUntil { background.endCount == 1 }
+    #expect(background.activeTaskName == nil)
+    #expect(store.state.liveChat == nil)
+
+    // A stale OS expiry is now a client-side no-op (the task already ended) and the
+    // cancelled listener can't deliver anything anyway.
+    background.expire()
+    #expect(background.endCount == 1)
   }
 
   // MARK: Push tap deep-link + foreground suppression + badge (C5)
@@ -1362,15 +1669,74 @@ struct AppFeatureTests {
     await store.finish()
     #expect(push.currentSession == "20260610_abc")
 
-    // Pop the chat (path empties) → current-viewing marker cleared (and, for now, the
-    // slot is torn down unconditionally — Task 2 adds the keep-while-running policy).
+    // Pop the chat (path empties) → current-viewing marker cleared immediately (the
+    // suppression follows the MARKER, not the slot); the idle teardown then runs once the
+    // view finished disappearing.
     await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
-    // Drain the pop's follow-up actions (persistNow → teardown → clearLiveChat) so the
-    // asserted state reflects the completed teardown.
+    await store.finish()
+    #expect(push.currentSession == nil)
+    await store.send(.chatViewDisappeared)
+    // Drain the teardown follow-ups (viewDisappeared → persistNow → teardown → clear) so
+    // the asserted state reflects the completed teardown.
     await store.skipReceivedActions()
     await store.finish()
     #expect(push.currentSession == nil)
     #expect(store.state.liveChat == nil)
+  }
+
+  /// Push suppression while DETACHED (T2): popping to the list with a still-RUNNING slot
+  /// clears the currently-viewing session (pushes for it must present again — the user
+  /// isn't looking at it), and re-attaching restores it.
+  @Test func detachedSlotClearsCurrentViewingUntilReattached() async {
+    let push = PushClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.status = .ready
+    chat.hasRequestedSession = true
+    chat.hasStarted = true
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.push = push.client
+      $0.hermesGateway.send = { @Sendable method, _ in
+        guard method == "session.resume" else { return .object([:]) }
+        return .object([
+          "session_id": .string("live1"),
+          "stored_session_id": .string("s1"),
+          "messages": .array([]),
+          "running": .bool(true),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Pop while running: slot kept, but the suppression marker clears — a push for "s1"
+    // must present while the user browses the list.
+    await store.send(.path(.popFrom(id: store.state.path.ids.last!)))
+    await store.finish()
+    #expect(store.state.liveChat != nil)
+    #expect(push.currentSession == nil)
+
+    // Re-attach from the list → the marker (and with it the suppression) is back.
+    await store.send(.home(.delegate(.openSession(Session(id: "s1")))))
+    await store.receive(\.liveChat.reattached)
+    await store.skipReceivedActions()
+    await waitUntil { push.currentSession == "s1" }
+
+    await store.send(.liveChat(.teardown))
   }
 
   /// An approval tap with no session list yet (can't open) bumps the pending-approval badge;
@@ -1530,6 +1896,7 @@ struct AppFeatureTests {
     await store.receive(\.home.delegate.openSession)
     await store.receive(\.liveChat.persistNow)
     await store.receive(\.liveChat.teardown)
+    await store.receive(\.clearLiveChat)
     await store.receive(\.fillLiveChat)
     // Path SET, not appended: exactly one marker, pointing at the new session.
     #expect(store.state.path.count == 1)

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -946,6 +946,226 @@ struct AppFeatureTests {
     #expect(snapshotClient.loadSnapshot("s1")?.updatedAt == Date(timeIntervalSince1970: 7))
   }
 
+  // MARK: Background grace window (Task 5)
+
+  /// `.background` with a RUNNING turn begins the finite background window and leaves the
+  /// socket streaming: the snapshot flush lands, the grace task starts, and a gateway event
+  /// arriving while backgrounded still mutates the slot (nothing was torn down).
+  @Test func backgroundWhileRunningBeginsGraceAndKeepsSocketStreaming() async {
+    let background = BackgroundTaskClient.inMemory()
+    let socketClosed = LockIsolated(false)
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        AsyncStream { continuation in
+          continuation.onTermination = { _ in socketClosed.setValue(true) }
+        }
+      }
+      $0.hermesREST.sessions = { @Sendable _, _, _, _ in [] }
+      $0.hermesREST.cronJobs = { @Sendable _, _ in throw RESTError.notFound }
+      $0.hermesProfiles.list = { @Sendable _ in throw RESTError.notFound }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    // Dial the slot's socket (first appearance).
+    await store.send(.liveChat(.task))
+
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+
+    // The grace task was begun...
+    while background.beginCount == 0 { await Task.yield() }
+    #expect(background.activeTaskName == "hermes.chat.background-grace")
+    // ...and the socket is untouched: a streaming delta still reduces into the slot.
+    #expect(socketClosed.value == false)
+    await store.send(.liveChat(.gatewayEvent(.messageDelta(text: "still streaming"))))
+    #expect(store.state.liveChat?.transcript.isEmpty == false)
+
+    // Cleanup: returning active cancels the grace listener + ends the task.
+    await store.send(.scenePhaseChanged(.active))
+    await store.send(.liveChat(.teardown))
+    await store.send(.home(.onDisappear))
+  }
+
+  /// The window expiring while still backgrounded flushes the snapshot one final time,
+  /// disconnects the socket cleanly (`.teardownSocketOnly` — cancelled, so no trailing
+  /// `.gatewayClosed` backoff), ends the task, and RETAINS the chat state in memory —
+  /// transcript, live thinking-row pointer, composer draft — so the foreground hydrate's
+  /// #26 preservation still applies.
+  @Test func graceExpiryDisconnectsSocketAndRetainsChatState() async {
+    let background = BackgroundTaskClient.inMemory()
+    let snapshotClient = ChatSnapshotClient.inMemory()
+    let socketClosed = LockIsolated(false)
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+    chat.model = "claude-opus-4-8"
+    chat.composerText = "unsent draft"
+    let thinkingID = UUID(uuidString: "00000000-0000-0000-0000-00000000AAAA")!
+    chat.transcript = [
+      ChatRow(id: thinkingID, kind: .thinking(
+        reasoning: "live reasoning", status: nil, elapsedSeconds: 3, isComplete: false
+      ))
+    ]
+    chat.thinkingRowID = thinkingID
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = snapshotClient
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        AsyncStream { continuation in
+          continuation.onTermination = { _ in socketClosed.setValue(true) }
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.liveChat(.task))
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+    while background.beginCount == 0 { await Task.yield() }
+
+    // iOS expires the window while still backgrounded.
+    background.expire()
+    await store.receive(\.backgroundGraceExpired)
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardownSocketOnly) {
+      $0.liveChat?.status = .reconnecting
+    }
+
+    // The socket effect was cancelled (stream terminated) with no `.gatewayClosed` backoff,
+    // the task was ended, and the chat state survived in memory.
+    while !socketClosed.value { await Task.yield() }
+    #expect(background.endCount == 1)
+    #expect(background.activeTaskName == nil)
+    #expect(store.state.liveChat != nil)
+    #expect(store.state.liveChat?.composerText == "unsent draft")
+    #expect(store.state.liveChat?.thinkingRowID == thinkingID)
+    #expect(store.state.liveChat?.transcript[id: thinkingID] != nil)
+    // The final flush landed before the disconnect.
+    #expect(snapshotClient.loadSnapshot("s1")?.model == "claude-opus-4-8")
+  }
+
+  /// Returning `.active` before the window expires ends the background task (and cancels
+  /// the expiry listener) WITHOUT the grace teardown — no socket-only disconnect fires, and
+  /// a stale expiry after the fact is a no-op. The existing `.foreground` fan-out runs
+  /// unchanged.
+  @Test func activeBeforeExpiryEndsGraceTaskWithoutSocketTeardown() async {
+    let background = BackgroundTaskClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.isSending = true
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.hermesGateway.connect = { @Sendable _, _ in AsyncStream { _ in } }
+      $0.hermesREST.sessions = { @Sendable _, _, _, _ in [] }
+      $0.hermesREST.cronJobs = { @Sendable _, _ in throw RESTError.notFound }
+      $0.hermesProfiles.list = { @Sendable _ in throw RESTError.notFound }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+    while background.beginCount == 0 { await Task.yield() }
+
+    await store.send(.scenePhaseChanged(.active))
+    await store.receive(\.liveChat.foreground)
+    await store.receive(\.home.pulledToRefresh)
+
+    // Task ended by `.active`; a stale expiry can no longer fire (nothing active).
+    while background.endCount == 0 { await Task.yield() }
+    #expect(background.activeTaskName == nil)
+    background.expire()
+    #expect(background.endCount == 1)
+    // No socket-only disconnect happened (it would have flipped status to `.reconnecting`).
+    #expect(store.state.liveChat?.status == .connecting)
+
+    await store.send(.liveChat(.teardown))
+    await store.send(.home(.onDisappear))
+  }
+
+  /// `.background` with an IDLE chat flushes only — no background task is begun (nothing to
+  /// keep alive, no battery burn).
+  @Test func backgroundWhileIdleStartsNoGraceTask() async {
+    let background = BackgroundTaskClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.backgroundTask = background.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.scenePhaseChanged(.background))
+    await store.receive(\.liveChat.persistNow)
+    #expect(background.beginCount == 0)
+  }
+
+  /// `.background` with no slot at all is a no-op (exhaustive: no state change, no effects —
+  /// in particular no background task).
+  @Test func backgroundWithNoSlotIsNoOp() async {
+    let background = BackgroundTaskClient.inMemory()
+    let store = TestStore(
+      initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.backgroundTask = background.client
+    }
+
+    await store.send(.scenePhaseChanged(.background))
+    #expect(background.beginCount == 0)
+  }
+
   // MARK: Push tap deep-link + foreground suppression + badge (C5)
 
   /// A push tap routes through the SAME `openSession` delegate path a list tap uses, opening

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -1295,6 +1295,122 @@ struct AppFeatureTests {
     #expect(store.state.pendingApprovalSessionIDs.isEmpty)
   }
 
+  /// A tap for the session that is ALREADY on screen (slot match + marker in the path) must
+  /// not navigate at all (#32) — no `openSession`, no duplicate marker, no slot re-init. An
+  /// approval tap still runs its badge bookkeeping (mark-then-clear nets zero: the user is
+  /// viewing the session).
+  @Test func pushTapForOnScreenSessionDoesNotNavigate() async {
+    let push = PushClient.inMemory()
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.push = push.client
+    }
+
+    // Exhaustive: any follow-up action (an `openSession`, a path mutation) would fail the
+    // test. The approval's mark-then-clear leaves the state byte-identical; only the badge
+    // side effect runs.
+    await store.send(.pushTapped(PushTap(sessionID: "s1", type: "approval")))
+    await store.finish()
+    #expect(store.state.path.count == 1)
+    #expect(store.state.path.last?.sessionKey == "s1")
+    #expect(store.state.liveChat?.storedSessionID == "s1")
+    #expect(push.badgeCount == 0)
+
+    // A plain (non-approval) tap for the on-screen session is equally a no-nav no-op.
+    await store.send(.pushTapped(PushTap(sessionID: "s1")))
+    await store.finish()
+    #expect(store.state.path.count == 1)
+  }
+
+  /// A tap matching the DETACHED slot's session (user popped to the list mid-turn) routes
+  /// through `openSession`'s re-attach branch: the marker is pushed back exactly once (no
+  /// duplicate) and the slot state — accumulated rows, composer draft — is NOT re-inited.
+  @Test func pushTapForDetachedSlotSessionReattachesWithoutDuplicate() async {
+    var chat = ChatFeature.State(connection: connection, resumeStoredID: "s1")
+    chat.liveSessionID = "live1"
+    chat.status = .ready
+    chat.hasRequestedSession = true
+    chat.hasStarted = true
+    chat.composerText = "unsent draft"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection, sessions: [Session(id: "s1")]),
+        // Empty path — the user is on the list; the slot streams detached.
+        liveChat: chat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, _ in
+        guard method == "session.resume" else { return .object([:]) }
+        return .object([
+          "session_id": .string("live1"),
+          "stored_session_id": .string("s1"),
+          "messages": .array([]),
+          "running": .bool(false),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.pushTapped(PushTap(sessionID: "s1")))
+    await store.receive(\.home.delegate.openSession)
+    await store.receive(\.liveChat.reattached)
+    // Marker pushed back exactly once; the slot state survived (no fresh `ChatFeature.State`).
+    #expect(store.state.path.count == 1)
+    #expect(store.state.path.last?.sessionKey == "s1")
+    #expect(store.state.liveChat?.composerText == "unsent draft")
+
+    await store.send(.liveChat(.teardown))
+  }
+
+  /// A tap for a DIFFERENT session while the slot is occupied replaces the slot (flush +
+  /// teardown first) and SETS the path to the single new marker — never appends on top of
+  /// the old one (#32's stacking bug).
+  @Test func pushTapForDifferentSessionReplacesSlotAndSetsPath() async {
+    var liveChat = ChatFeature.State(connection: connection, resumeStoredID: "old")
+    liveChat.liveSessionID = "old-live"
+
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        path: StackState([ChatScreen.State(sessionKey: "old")]),
+        liveChat: liveChat
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "new")))
+    await store.receive(\.home.delegate.openSession)
+    await store.receive(\.liveChat.persistNow)
+    await store.receive(\.liveChat.teardown)
+    await store.receive(\.fillLiveChat)
+    // Path SET, not appended: exactly one marker, pointing at the new session.
+    #expect(store.state.path.count == 1)
+    #expect(store.state.path.last?.sessionKey == "new")
+    #expect(store.state.liveChat?.storedSessionID == "new")
+  }
+
   /// Two distinct pending approvals → badge count 2; opening one → badge drops to 1.
   @Test func multiplePendingApprovalsSetBadgeThenClearOne() async {
     let push = PushClient.inMemory()

--- a/HermesKit/Tests/HermesKitTests/BackgroundTaskClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/BackgroundTaskClientTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import Testing
+
+@testable import HermesKit
+
+struct BackgroundTaskClientTests {
+  // MARK: Begin/end bookkeeping
+
+  @Test func beginTracksActiveTaskAndEndClearsIt() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    _ = await client.begin("grace")
+    #expect(inMemory.activeTaskName == "grace")
+    #expect(inMemory.beginCount == 1)
+    #expect(inMemory.endCount == 0)
+
+    await client.end()
+    #expect(inMemory.activeTaskName == nil)
+    #expect(inMemory.endCount == 1)
+  }
+
+  @Test func endIsIdempotentWithNoActiveTask() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    // No task begun — end must be a safe no-op (called unconditionally on `.active`).
+    await client.end()
+    #expect(inMemory.endCount == 0)
+
+    _ = await client.begin("grace")
+    await client.end()
+    await client.end()
+    // The begun task is ended exactly once; the second end is a no-op.
+    #expect(inMemory.endCount == 1)
+  }
+
+  @Test func normalEndFinishesStreamWithoutYield() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    let stream = await client.begin("grace")
+    await client.end()
+
+    var yields = 0
+    for await _ in stream { yields += 1 }
+    // A clean end (`.active` before the window ran out) must NOT look like an expiry.
+    #expect(yields == 0)
+  }
+
+  // MARK: Expiry
+
+  @Test func expiryYieldsExactlyOnceAndEndsTheTask() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    let stream = await client.begin("grace")
+    inMemory.expire()
+    inMemory.expire() // a second expiry must not double-fire
+
+    var yields = 0
+    for await _ in stream { yields += 1 }
+    // Finite loop (stream finished after the single yield); one expiry signal only.
+    #expect(yields == 1)
+    // Expiry performs the mandatory end bookkeeping itself.
+    #expect(inMemory.activeTaskName == nil)
+    #expect(inMemory.endCount == 1)
+  }
+
+  @Test func endAfterExpiryIsANoOp() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    _ = await client.begin("grace")
+    inMemory.expire()
+    await client.end()
+    // Already ended by the expiration bookkeeping — no double end.
+    #expect(inMemory.endCount == 1)
+  }
+
+  // MARK: Double-begin replacement
+
+  @Test func doubleBeginReplacesThePriorTask() async {
+    let inMemory = BackgroundTaskClient.inMemory()
+    let client = inMemory.client
+
+    let first = await client.begin("first")
+    let second = await client.begin("second")
+
+    // The prior task was ended by the replacement; its stream finished without a yield.
+    var firstYields = 0
+    for await _ in first { firstYields += 1 }
+    #expect(firstYields == 0)
+    #expect(inMemory.activeTaskName == "second")
+    #expect(inMemory.beginCount == 2)
+    #expect(inMemory.endCount == 1)
+
+    // Expiry targets the replacement, not the replaced task.
+    inMemory.expire()
+    var secondYields = 0
+    for await _ in second { secondYields += 1 }
+    #expect(secondYields == 1)
+    #expect(inMemory.endCount == 2)
+  }
+
+  // MARK: Test double
+
+  @Test func testValueBeginReturnsFinishedStreamAndEndIsNoOp() async {
+    let client = BackgroundTaskClient.testValue
+
+    let stream = await client.begin("anything")
+    var yields = 0
+    for await _ in stream { yields += 1 }
+    // Already-finished stream: never signals expiry, never hangs a for-await.
+    #expect(yields == 0)
+
+    await client.end() // must not trip an unimplemented-dependency failure
+  }
+}

--- a/HermesKit/Tests/HermesKitTests/ChatInteractionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatInteractionTests.swift
@@ -317,6 +317,8 @@ struct ChatInteractionTests {
       $0.errorBanner = "Prompt failed: request timed out: prompt.submit"
       $0.isSending = false
     }
+    // Client-side turn end → the slot-teardown/glow delegate fires (no server event follows).
+    await store.receive(\.delegate.runningChanged)
   }
 
   struct PlainError: Error {}
@@ -342,6 +344,8 @@ struct ChatInteractionTests {
       $0.errorBanner = "Prompt failed: Connection lost."
       $0.isSending = false
     }
+    // Client-side turn end → the slot-teardown/glow delegate fires (no server event follows).
+    await store.receive(\.delegate.runningChanged)
   }
 
   // Interrupting mid-turn freezes the live thinking row (bakes the elapsed, isComplete=true)

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -201,8 +201,8 @@ struct ChatReductionTests {
     }
   }
 
-  // Leaving the screen mid-turn cancels the live thinking timer (no leaked tick loop).
-  @Test func onDisappearCancelsThinkingTimer() async {
+  // Slot teardown mid-turn cancels the live thinking timer (no leaked tick loop).
+  @Test func teardownCancelsThinkingTimer() async {
     let clock = TestClock()
     let store = TestStore(initialState: ChatFeature.State(connection: conn)) {
       ChatFeature()
@@ -218,8 +218,8 @@ struct ChatReductionTests {
     }
     await clock.advance(by: .seconds(1))
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 1 }
-    // onDisappear cancels the loop; advancing further yields no more ticks.
-    await store.send(.onDisappear)
+    // Teardown cancels the loop; advancing further yields no more ticks.
+    await store.send(.teardown)
     await clock.advance(by: .seconds(5))
   }
 
@@ -267,7 +267,7 @@ struct ChatReductionTests {
     }
     await clock.advance(by: .seconds(1))
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 1 }
-    await store.send(.onDisappear)
+    await store.send(.teardown)
     await clock.advance(by: .seconds(3))
   }
 
@@ -302,7 +302,7 @@ struct ChatReductionTests {
       $0.thinkingRowID = uuid(1)
       $0.thinkingSeconds = 0
     }
-    await store.send(.onDisappear)
+    await store.send(.teardown)
     await clock.advance(by: .seconds(3))
   }
 
@@ -364,7 +364,7 @@ struct ChatReductionTests {
       $0.reconnectAttempt = 1
     }
     #expect(store.state.transcript.isEmpty)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // A bare thinkingDelta arriving FIRST (no prior message.start) defensively creates the
@@ -551,7 +551,9 @@ struct ChatReductionTests {
       }
     }
 
-    await store.send(.task)
+    await store.send(.task) {
+      $0.hasStarted = true
+    }
     await store.receive(\.gatewayEvent) {
       $0.status = .ready
       $0.hasRequestedSession = true
@@ -565,7 +567,7 @@ struct ChatReductionTests {
     #expect(sent.value?["method"]?.stringValue == "session.create")
     #expect(sent.value?["params"] == .object([:]))
     #expect(sent.value?["params"]?["title"] == nil)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func createUnderCustomProfileThreadsProfileParam() async {
@@ -588,7 +590,9 @@ struct ChatReductionTests {
       }
     }
 
-    await store.send(.task)
+    await store.send(.task) {
+      $0.hasStarted = true
+    }
     await store.receive(\.gatewayEvent) {
       $0.status = .ready
       $0.hasRequestedSession = true
@@ -600,7 +604,7 @@ struct ChatReductionTests {
     }
     #expect(sent.value?["method"]?.stringValue == "session.create")
     #expect(sent.value?["params"] == .object(["profile": .string("work")]))
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func defaultProfileNameThreadsNoProfileParam() async {
@@ -624,7 +628,9 @@ struct ChatReductionTests {
       }
     }
 
-    await store.send(.task)
+    await store.send(.task) {
+      $0.hasStarted = true
+    }
     await store.receive(\.gatewayEvent) {
       $0.status = .ready
       $0.hasRequestedSession = true
@@ -635,7 +641,7 @@ struct ChatReductionTests {
       $0.status = .ready
     }
     #expect(sent.value?["params"] == .object([:]))
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func resumeUnderCustomProfileThreadsProfileParam() async {
@@ -683,7 +689,7 @@ struct ChatReductionTests {
     ]))
     // Activate's authoritative `running:false` clears the list glow for this session.
     await store.receive(\.delegate.runningChanged)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func readyWithStoredIDHydratesViaResume() async {
@@ -732,7 +738,7 @@ struct ChatReductionTests {
     // Usage came from `info` — no fallback `session.usage` fetch.
     #expect(!methods.value.contains("session.usage"))
     await store.receive(\.delegate.runningChanged)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func resumeWithNoUsageInResponseFallsBackToUsageFetch() async {
@@ -781,7 +787,7 @@ struct ChatReductionTests {
     #expect(methods.value.first == "session.resume")
     #expect(methods.value.contains("session.usage"))
     #expect(usageParams.value?["session_id"]?.stringValue == "live123")
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func resumeHydratesStoredTranscriptModelAndUsage() async {
@@ -834,7 +840,7 @@ struct ChatReductionTests {
     // Single resume call — no activate, no fallback dance.
     #expect(methods.value == ["session.resume"])
     await store.receive(\.delegate.runningChanged)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func activateSeedsRunningInflightAndDeltaReusesSeededRow() async {
@@ -906,7 +912,7 @@ struct ChatReductionTests {
     }
     // user + assistant + thinking = 3 rows (no duplicate assistant from the delta).
     #expect(store.state.transcript.count == 3)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func unknownEventIsInertInTheFold() async {
@@ -992,7 +998,7 @@ struct ChatReductionTests {
     }
     await clock.advance(by: .seconds(1)) // first backoff = 2^0 = 1s
     await store.receive(\.reconnectTick)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: ws-ticket auth failure vs transient (gated reconnect)
@@ -1024,7 +1030,7 @@ struct ChatReductionTests {
     await store.send(.gatewayClosed)
     // No `.reconnectTick` is ever scheduled even after a long advance.
     await clock.advance(by: .seconds(60))
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   /// A transient gated failure (the ticket mint failed → the stream just finishes, like a
@@ -1049,7 +1055,7 @@ struct ChatReductionTests {
     }
     await clock.advance(by: .seconds(1)) // first backoff = 2^0 = 1s
     await store.receive(\.reconnectTick)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Reconnect resilience — finalize a row that was mid-stream when the socket dropped
@@ -1083,7 +1089,7 @@ struct ChatReductionTests {
       $0.isSending = false
       $0.reconnectAttempt = 1
     }
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Copy a row to the pasteboard

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -223,6 +223,48 @@ struct ChatReductionTests {
     await clock.advance(by: .seconds(5))
   }
 
+  // Background-grace expiry: `.teardownSocketOnly` cancels the socket effect WITHOUT its
+  // trailing `.gatewayClosed` (so no backoff reconnect is scheduled while suspended) and
+  // leaves the in-flight turn state intact — live thinking row, pointers, `isSending` —
+  // for the #26-preserving foreground hydrate. Only the status flips to `.reconnecting`
+  // (the socket is genuinely gone, so a later `.reattached` redials instead of hydrating
+  // a dead socket).
+  @Test func teardownSocketOnlyKeepsInFlightStateAndSkipsBackoff() async {
+    let clock = TestClock()
+    let socketClosed = LockIsolated(false)
+    let store = TestStore(initialState: ChatFeature.State(connection: conn)) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = clock
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        AsyncStream { continuation in
+          continuation.onTermination = { _ in socketClosed.setValue(true) }
+        }
+      }
+    }
+
+    await store.send(.task) { $0.hasStarted = true }
+    await store.send(.gatewayEvent(.messageStart)) {
+      $0.isSending = true
+      $0.transcript = [ChatRow(id: uuid(0), kind: .thinking(reasoning: "", status: nil, elapsedSeconds: 0, isComplete: false))]
+      $0.thinkingRowID = uuid(0)
+    }
+
+    await store.send(.teardownSocketOnly) {
+      $0.status = .reconnecting
+    }
+    // The socket effect terminated by CANCELLATION — the exhaustive store proves the
+    // trailing `.gatewayClosed` was dropped (no reconnect backoff, no in-flight finalize).
+    while !socketClosed.value { await Task.yield() }
+    #expect(store.state.isSending)
+    #expect(store.state.thinkingRowID == uuid(0))
+
+    // The thinking ticker deliberately stays (the hydrate's `reconcileTimer` owns it);
+    // full teardown cleans it up.
+    await store.send(.teardown)
+  }
+
   // Two back-to-back turns: a second message.start (with no intervening message.complete)
   // freezes/clears the first live row before creating the second, and the timer restarts
   // cleanly from 0 (cancelInFlight + reset) — no orphaned shimmering row, no double-ticking.

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -232,7 +232,11 @@ struct ChatReductionTests {
   @Test func teardownSocketOnlyKeepsInFlightStateAndSkipsBackoff() async {
     let clock = TestClock()
     let socketClosed = LockIsolated(false)
-    let store = TestStore(initialState: ChatFeature.State(connection: conn)) {
+    var initial = ChatFeature.State(connection: conn)
+    // Seed the hydrate guard as a `.ready` would have left it, so `.teardownSocketOnly`'s
+    // reset (the next `.ready` must genuinely re-hydrate) is observable below.
+    initial.hasRequestedSession = true
+    let store = TestStore(initialState: initial) {
       ChatFeature()
     } withDependencies: {
       $0.uuid = .incrementing
@@ -253,15 +257,56 @@ struct ChatReductionTests {
 
     await store.send(.teardownSocketOnly) {
       $0.status = .reconnecting
+      $0.hasRequestedSession = false
     }
     // The socket effect terminated by CANCELLATION — the exhaustive store proves the
     // trailing `.gatewayClosed` was dropped (no reconnect backoff, no in-flight finalize).
-    while !socketClosed.value { await Task.yield() }
+    await waitUntil { socketClosed.value }
     #expect(store.state.isSending)
     #expect(store.state.thinkingRowID == uuid(0))
 
     // The thinking ticker deliberately stays (the hydrate's `reconcileTimer` owns it);
     // full teardown cleans it up.
+    await store.send(.teardown)
+  }
+
+  // `.viewDisappeared` (the screen left — forwarded by `AppFeature.chatViewDisappeared`)
+  // releases only the VIEW-session resources: recording state reset + mic released. The
+  // slot's long-running effects are untouched — the thinking ticker (a stand-in for the
+  // socket/persist effects rooted alongside it) keeps firing after the view is gone.
+  @Test func viewDisappearedReleasesMicButKeepsSlotEffects() async {
+    let clock = TestClock()
+    let micCancelled = LockIsolated(false)
+    var initial = ChatFeature.State(connection: conn)
+    initial.recording = .recording
+    initial.waveformLevels = [0.4, 0.8]
+    initial.recordingSeconds = 7
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = clock
+      $0.audioRecorder.cancel = { micCancelled.setValue(true) }
+    }
+
+    // A turn is running: the live thinking row + elapsed ticker are slot-rooted effects.
+    await store.send(.gatewayEvent(.messageStart)) {
+      $0.isSending = true
+      $0.transcript = [ChatRow(id: uuid(0), kind: .thinking(reasoning: "", status: nil, elapsedSeconds: 0, isComplete: false))]
+      $0.thinkingRowID = uuid(0)
+    }
+
+    await store.send(.viewDisappeared) {
+      $0.recording = .idle
+      $0.waveformLevels = []
+      $0.recordingSeconds = 0
+    }
+    // The mic/recording session was released…
+    await waitUntil { micCancelled.value }
+    // …but the slot's effects survived the view: the ticker still fires.
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.thinkingTick) { $0.thinkingSeconds = 1 }
+
     await store.send(.teardown)
   }
 
@@ -571,6 +616,22 @@ struct ChatReductionTests {
     #expect(store.state.canSend == false)
     await store.send(.composerSubmitted)
     #expect(didSend.value == false)
+  }
+
+  // The visible send button becomes the interrupt button mid-turn, but a hardware-keyboard
+  // return still fires the TextField's `.onSubmit`. A submit while a turn streams must be a
+  // strict no-op — a second in-flight submit corrupts `isSending`, and if it later failed it
+  // would emit a spurious `runningChanged(false)` that tears down a detached slot whose
+  // first turn is still genuinely running. Exhaustive: any state change or effect fails this.
+  @Test func submitWhileSendingIsNoOp() async {
+    var initial = ChatFeature.State(connection: conn, status: .ready)
+    initial.liveSessionID = "live"
+    initial.composerText = "second message typed mid-turn"
+    initial.isSending = true
+    let store = TestStore(initialState: initial) { ChatFeature() }
+
+    #expect(initial.canSend == false)
+    await store.send(.composerSubmitted)
   }
 
   // MARK: Bootstrap (create on first ready)
@@ -1482,6 +1543,8 @@ struct ChatReductionTests {
       $0.isSending = false
       $0.attachments[0].uploadState = .failed("boom")
     }
+    // Client-side turn end → the slot-teardown/glow delegate fires (no server event follows).
+    await store.receive(\.delegate.runningChanged)
     #expect(store.state.composerText == "keep me") // input preserved for retry
     #expect(store.state.attachments.count == 1)
     #expect(methods.value == ["image.attach_bytes"]) // never reached prompt.submit
@@ -1514,6 +1577,8 @@ struct ChatReductionTests {
       $0.errorBanner = "This Hermes agent is too old to accept attachments. Update the agent to send files."
       $0.attachments[0].uploadState = .failed("Attachments not supported")
     }
+    // Client-side turn end → the slot-teardown/glow delegate fires (no server event follows).
+    await store.receive(\.delegate.runningChanged)
     #expect(methods.value == ["image.attach_bytes"]) // aborted before prompt.submit
     #expect(store.state.composerText == "hi") // input preserved
   }

--- a/HermesKit/Tests/HermesKitTests/ChatWindowingTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatWindowingTests.swift
@@ -154,7 +154,7 @@ struct ChatWindowingTests {
     #expect(store.state.windowStart == store.state.transcript.count - ChatFeature.State.initialWindow)
     #expect(store.state.visibleRows.last?.id == store.state.transcript.last?.id)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   /// A user who scrolled up (loaded older history) is NOT yanked back to the bottom when a new
@@ -174,7 +174,7 @@ struct ChatWindowingTests {
     #expect(store.state.windowStart == 0)
     #expect(store.state.hasMoreAbove == false)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Hydrate resets to the bottom window
@@ -207,7 +207,7 @@ struct ChatWindowingTests {
     #expect(store.state.visibleRows.last?.id == store.state.transcript.last?.id)
     #expect(store.state.hasMoreAbove)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   /// Even after scrolling up, a re-hydrate snaps the window back to the bottom.
@@ -237,6 +237,6 @@ struct ChatWindowingTests {
     await store.send(.activateResult(.success(response)))
     #expect(store.state.windowStart == ChatFeature.State.bottomWindowStart(count: store.state.transcript.count))
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 }

--- a/HermesKit/Tests/HermesKitTests/HydrateTests.swift
+++ b/HermesKit/Tests/HermesKitTests/HydrateTests.swift
@@ -131,7 +131,7 @@ struct HydrateTests {
     #expect(store.state.transcript[id: self.uuid(10)] == nil)
     // Activate's authoritative `running:false` clears the list glow for this session.
     await store.receive(\.delegate.runningChanged)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Cold-resume usage preservation + stale-banner clearing
@@ -189,7 +189,7 @@ struct HydrateTests {
     #expect(store.state.usage == cachedUsage)
     #expect(store.state.errorBanner == nil)
     #expect(store.state.status == .ready)
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func realProtocolErrorStillRaisesBanner() async {
@@ -211,7 +211,7 @@ struct HydrateTests {
       $0.errorBanner = "boom"
       $0.status = .reconnecting
     }
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Offline keeps the cache + reconnecting status
@@ -308,7 +308,7 @@ struct HydrateTests {
     #expect(saved?.rows == [ChatRow(id: self.uuid(0), kind: .message(role: .assistant, text: "hello there", isComplete: true))])
     #expect(saved?.updatedAt == Date(timeIntervalSince1970: 123))
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func burstOfDeltasCoalescesIntoOnePersist() async {
@@ -343,7 +343,7 @@ struct HydrateTests {
     let saved = snapshotClient.loadSnapshot("stored123")
     #expect(saved?.rows.last?.copyText == "abc")
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Task 6 — turn-start anchor + timer continuity
@@ -398,7 +398,7 @@ struct HydrateTests {
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 8 }
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 9 }
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func hydrateRunningWithNoAnchorTicksFromZero() async {
@@ -432,7 +432,7 @@ struct HydrateTests {
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 1 }
     await store.receive(\.thinkingTick) { $0.thinkingSeconds = 2 }
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func hydrateNotRunningWithStaleAnchorFreezesAndDiscardsAnchor() async {
@@ -467,7 +467,7 @@ struct HydrateTests {
     // The stale anchor was discarded from the cache.
     #expect(snapshotClient.turnAnchor("stored123") == nil)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: #26 — preserve in-flight thinking + tool rows across foreground hydrate
@@ -528,7 +528,7 @@ struct HydrateTests {
     // Timer continuity: the preserved row's elapsed/reasoning did NOT reset; the tick resumes at 7.
     #expect(store.state.thinkingSeconds == 7)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func hydrateNotRunningWipesLiveThinkingAndToolRows() async {
@@ -569,7 +569,7 @@ struct HydrateTests {
     #expect(store.state.toolRowIDs.isEmpty)
     #expect(store.state.streamingRowID == nil)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   @Test func submitWritesAnchorAndCompleteClearsIt() async {
@@ -602,7 +602,7 @@ struct HydrateTests {
     await store.send(.gatewayEvent(.messageComplete(text: "done", usage: nil)))
     #expect(snapshotClient.turnAnchor("stored123") == nil)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Task 8 — background flush (`persistNow`)
@@ -722,7 +722,142 @@ struct HydrateTests {
       return false
     })
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
+  }
+
+  // MARK: Re-attach connect guard (keep-alive plan, Task 3)
+
+  // Re-opening a live slot must NOT cancel-and-redial a healthy socket — the dial gap would
+  // drop streamed events. `.reattached` with `status == .ready` hydrates directly against the
+  // live socket (zero `connect` calls) and the socket keeps folding deltas throughout.
+  @Test func reattachWithLiveSocketHydratesWithoutRedial() async {
+    let connectCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+    initial.isSending = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+      $0.hermesGateway.send = { @Sendable method, _ in
+        // The hydrate may fan out a follow-up (e.g. `session.usage`); only `session.resume`
+        // matters here — and crucially, NO `connect` redial happens (asserted below).
+        guard method == "session.resume" else { return .object([:]) }
+        return .object([
+          "session_id": .string("live123"),
+          "stored_session_id": .string("stored123"),
+          "messages": .array([
+            .object(["id": .number(1), "role": .string("user"), "content": .string("prior question")]),
+          ]),
+          "running": .bool(true),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+          "inflight": .object(["assistant": .string("partial answer"), "streaming": .bool(true)]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.reattached)
+    await store.receive(\.activateResult.success)
+
+    // Hydrate landed (server authority) — but the healthy socket was never redialed.
+    #expect(connectCalls.value == 0)
+    #expect(store.state.model == "claude-opus-4-8")
+    #expect(store.state.isSending == true)
+    #expect(store.state.status == .ready)
+
+    // The live socket keeps streaming: the next delta appends to the seeded in-flight row
+    // (proof the fold never went through a `.gatewayClosed`/reconnect cycle).
+    await store.send(.gatewayEvent(.messageDelta(text: " continues")))
+    #expect(store.state.transcript.contains { row in
+      if case let .message(role, text, isComplete) = row.kind {
+        return role == .assistant && text == "partial answer continues" && !isComplete
+      }
+      return false
+    })
+
+    await store.send(.teardown)
+  }
+
+  // `.reattached` with a DEAD socket recovers exactly like `.foreground`: reset the hydrate
+  // guard and reconnect — the fresh `.ready` re-hydrates.
+  @Test func reattachWithDeadSocketReconnectsAndRehydrates() async {
+    let connectCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .reconnecting
+    // Stale-true (the dropped `.gatewayClosed` reset, same as the fast-foreground case) —
+    // reattach must reset it so the fresh `.ready` actually hydrates.
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { continuation in continuation.yield(.ready) }
+      }
+      $0.hermesGateway.send = { @Sendable _, _ in
+        .object([
+          "session_id": .string("live123"),
+          "stored_session_id": .string("stored123"),
+          "messages": .array([]),
+          "running": .bool(false),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.reattached) {
+      $0.hasRequestedSession = false
+    }
+    await store.receive(\.gatewayEvent) {
+      $0.status = .ready
+      $0.hasRequestedSession = true
+    }
+    await store.receive(\.activateResult.success)
+    #expect(connectCalls.value == 1)
+    #expect(store.state.model == "claude-opus-4-8")
+
+    await store.send(.teardown)
+  }
+
+  // The view's `.task` fires on every appearance; once the slot has started (initial
+  // connect done), a re-appearance must be a strict no-op — `AppFeature`'s `.reattached`
+  // owns the re-open flow. Exhaustive: any effect or state change fails this.
+  @Test func taskAfterInitialConnectIsNoOp() async {
+    let connectCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+    }
+
+    await store.send(.task)
+    #expect(connectCalls.value == 0)
   }
 
   // MARK: Stable in-flight row identity across repeated hydrates (review finding #4)
@@ -799,7 +934,7 @@ struct HydrateTests {
       return false
     })
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Instant-paint + delta-before-activate race
@@ -863,6 +998,6 @@ struct HydrateTests {
     // No trace of the cached or stray rows.
     #expect(!store.state.transcript.contains { if case let .message(_, t, _) = $0.kind { return t.contains("stray") || t.contains("cached") }; return false })
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 }

--- a/HermesKit/Tests/HermesKitTests/HydrateTests.swift
+++ b/HermesKit/Tests/HermesKitTests/HydrateTests.swift
@@ -236,12 +236,17 @@ struct HydrateTests {
       ChatFeature.State(connection: conn, resumeStoredID: "stored123")
     }
 
+    let connectCalls = LockIsolated(0)
     let store = TestStore(initialState: initial) {
       ChatFeature()
     } withDependencies: {
       $0.uuid = .incrementing
       $0.continuousClock = TestClock()
       $0.chatSnapshot = snapshotClient
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
       $0.hermesGateway.send = { @Sendable _, _ in throw GatewayError.disconnected }
     }
 
@@ -252,13 +257,62 @@ struct HydrateTests {
     await store.receive(\.activateResult.failure) {
       // A dropped socket is conveyed by the reconnecting status alone — no banner is raised
       // for `.disconnected` (it would otherwise linger after reconnect; see the lock/unlock
-      // regression). The cached paint stays put.
+      // regression). The cached paint stays put. STATUS-ONLY: the teardown that resumed the
+      // RPC with `.disconnected` also finishes the event stream, so the companion
+      // `.gatewayClosed` owns the redial (with backoff) — an immediate redial here would
+      // defeat it (zero-backoff storm against a crash-looping server).
       $0.status = .reconnecting
     }
     // Cache still on screen — never blanked.
     #expect(Array(store.state.transcript) == cachedRows)
     #expect(store.state.model == "claude-opus-4-8")
     #expect(store.state.usage == Usage(contextUsed: 7, contextMax: 200_000, contextPercent: 0))
+    // No immediate redial — `.gatewayClosed`'s backoff owns reconnecting after a drop.
+    #expect(connectCalls.value == 0)
+    await store.send(.teardown)
+  }
+
+  // A `.disconnected` hydrate failure must not disturb the reconnect machinery: the
+  // companion `.gatewayClosed` (the same teardown finishes the event stream) schedules the
+  // escalating backoff, and the failure reducing alongside it must neither cancel that
+  // pending tick nor dial its own zero-delay connect (ordering race on an ordinary drop:
+  // the failure can land after `.gatewayClosed`).
+  @Test func disconnectedHydrateFailureKeepsPendingReconnectBackoff() async {
+    let connectCalls = LockIsolated(0)
+    let clock = TestClock()
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.continuousClock = clock
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+    }
+
+    // The socket died: the stream finished (backoff scheduled) AND the pending hydrate
+    // resumed `.disconnected` — in that order here (the racy interleaving from a real drop).
+    await store.send(.gatewayClosed) {
+      $0.status = .reconnecting
+      $0.hasRequestedSession = false
+      $0.reconnectAttempt = 1
+    }
+    await store.send(.activateResult(.failure(.disconnected)))
+    #expect(connectCalls.value == 0) // no zero-delay dial from the failure
+
+    // The backoff tick scheduled by `.gatewayClosed` survives and performs the one redial.
+    await clock.advance(by: .seconds(1))
+    await store.receive(\.reconnectTick)
+    await waitUntil { connectCalls.value == 1 }
+
+    await store.send(.teardown)
   }
 
   // MARK: Debounced write-back
@@ -838,6 +892,230 @@ struct HydrateTests {
     await store.send(.teardown)
   }
 
+  // `.foreground` shares `.reattached`'s connect guard: returning to the foreground INSIDE
+  // the background grace window (the socket kept streaming, `status == .ready`) must
+  // hydrate directly against the live socket — NOT cancel-and-redial the healthy
+  // connection the grace window just paid to keep alive (the dial gap drops events).
+  @Test func foregroundWithHealthySocketHydratesWithoutRedial() async {
+    let connectCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+      $0.hermesGateway.send = { @Sendable method, _ in
+        guard method == "session.resume" else { return .object([:]) }
+        return .object([
+          "session_id": .string("live123"),
+          "stored_session_id": .string("stored123"),
+          "messages": .array([]),
+          "running": .bool(false),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.foreground)
+    await store.receive(\.activateResult.success)
+
+    // Hydrate landed (server authority) — but the healthy socket was never redialed.
+    #expect(connectCalls.value == 0)
+    #expect(store.state.model == "claude-opus-4-8")
+    #expect(store.state.status == .ready)
+
+    await store.send(.teardown)
+  }
+
+  // Foregrounding an IDLE chat starts no background grace window, so after a suspension the
+  // status can be a stale `.ready` over a HALF-OPEN socket (NAT rebind): the hydrate RPC
+  // times out while `.gatewayClosed` may not fire for minutes. A single timeout is
+  // indistinguishable from a live-but-slow socket, so the first one retries the hydrate over
+  // the SAME socket; the SECOND consecutive timeout concludes half-open and the failure must
+  // schedule the redial ITSELF — not strand the chat in `.reconnecting` with no reconnect
+  // pending — and stays banner-less (transport-shaped, matching `.disconnected`).
+  @Test func hydrateTimeoutOverStaleReadySocketRedials() async {
+    let connectCalls = LockIsolated(0)
+    let resumeCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready // stale: the transport underneath is half-open
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+      $0.hermesGateway.send = { @Sendable method, _ in
+        if method == "session.resume" { resumeCalls.withValue { $0 += 1 } }
+        throw GatewayError.timedOut(method: method)
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.foreground)
+    // First timeout: retry once over the same (possibly just slow) socket — no redial yet.
+    await store.receive(\.activateResult.failure) {
+      $0.status = .reconnecting
+      $0.hydrateRetriedAfterTimeout = true
+    }
+    // Second consecutive silent timeout: half-open confirmed — redial ourselves.
+    await store.receive(\.activateResult.failure) {
+      $0.hydrateRetriedAfterTimeout = false
+      $0.hasRequestedSession = false // the fresh `.ready` must re-hydrate
+    }
+    await waitUntil { connectCalls.value == 1 }
+    #expect(resumeCalls.value == 2) // the original hydrate + one same-socket retry
+    #expect(store.state.errorBanner == nil) // transport-shaped: status conveys it, no banner
+
+    await store.send(.teardown)
+  }
+
+  // A `session.resume` that merely responds SLOWLY (>30s: huge history, busy gateway) over a
+  // socket that is alive must NOT be treated as half-open on the first timeout: the retry
+  // lands over the SAME socket (no redial), so a mid-turn stream is never killed by a slow
+  // hydrate.
+  @Test func slowHydrateTimeoutRetriesOverSameSocketWithoutRedial() async {
+    let connectCalls = LockIsolated(0)
+    let resumeCalls = LockIsolated(0)
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
+      $0.hermesGateway.send = { @Sendable method, _ in
+        guard method == "session.resume" else { return .object([:]) }
+        let attempt = resumeCalls.withValue { $0 += 1; return $0 }
+        // The first attempt "takes too long" (per-request timeout fires); the retry lands.
+        guard attempt > 1 else { throw GatewayError.timedOut(method: method) }
+        return .object([
+          "session_id": .string("live123"),
+          "stored_session_id": .string("stored123"),
+          "messages": .array([]),
+          "running": .bool(false),
+          "info": .object(["model": .string("claude-opus-4-8")]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.foreground)
+    await store.receive(\.activateResult.failure) {
+      $0.status = .reconnecting
+      $0.hydrateRetriedAfterTimeout = true
+    }
+    // The same-socket retry succeeds — server authority applied, retry budget reset.
+    await store.receive(\.activateResult.success) {
+      $0.status = .ready
+      $0.hydrateRetriedAfterTimeout = false
+    }
+    #expect(store.state.model == "claude-opus-4-8")
+    #expect(connectCalls.value == 0) // the live socket was never redialed
+    #expect(store.state.errorBanner == nil)
+
+    await store.send(.teardown)
+  }
+
+  // A hydrate failing `.timedOut` while the re-auth pause is up must do NOTHING: a redial
+  // would mint (and waste) a single-use ws-ticket against a dead gated session —
+  // `.resumeAfterReauth` owns the reconnect. Exhaustive: any effect fails this.
+  @Test func hydrateTimeoutDuringReauthPauseDoesNotRedial() async {
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .reconnecting // `.authExpired` already flipped it
+    initial.liveSessionID = "live123"
+    initial.hasStarted = true
+    initial.awaitingReauth = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    }
+
+    await store.send(.activateResult(.failure(.timedOut(method: "session.resume"))))
+  }
+
+  // A pending hydrate must die with a DELIBERATE socket-only teardown (background grace
+  // expiry): the socket cancellation resumes the RPC, and its stale `.activateResult` must
+  // NOT reduce afterwards — it would redial while the app is backgrounded, undoing the clean
+  // disconnect (and wasting a single-use ws-ticket in gated mode).
+  @Test func teardownSocketOnlyCancelsPendingHydrate() async {
+    var initial = ChatFeature.State(connection: conn, resumeStoredID: "stored123")
+    initial.status = .ready
+    initial.liveSessionID = "live123"
+    initial.hasRequestedSession = true
+    initial.hasStarted = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    } withDependencies: {
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable _, _ in
+        // Hang until cancelled (the empty stream never yields; cancellation ends the
+        // iteration), then surface the drop the way the live client would.
+        for await _ in AsyncStream<Never> { _ in } {}
+        throw GatewayError.disconnected
+      }
+    }
+
+    await store.send(.foreground) // hydrate now in flight, hanging
+    await store.send(.teardownSocketOnly) {
+      $0.status = .reconnecting
+      $0.hasRequestedSession = false
+    }
+    // Exhaustive: if the cancelled hydrate's `.activateResult` still reduced (or the effect
+    // outlived the teardown), `finish()` would fail.
+    await store.finish()
+  }
+
+  // `.reattached` / `.foreground` with a healthy socket but a STILL-UNRESOLVED session id
+  // (`session.create` in flight on that same socket) is a strict no-op — the pending
+  // create lands on its own; hydrating (or redialing) here would race it. Exhaustive: any
+  // effect or state change fails this.
+  @Test func reattachReadyWithUnresolvedSessionIsNoOp() async {
+    var initial = ChatFeature.State(connection: conn)
+    initial.status = .ready
+    initial.hasStarted = true
+    initial.hasRequestedSession = true
+
+    let store = TestStore(initialState: initial) {
+      ChatFeature()
+    }
+
+    await store.send(.reattached)
+    await store.send(.foreground)
+  }
+
   // The view's `.task` fires on every appearance; once the slot has started (initial
   // connect done), a re-appearance must be a strict no-op — `AppFeature`'s `.reattached`
   // owns the re-open flow. Exhaustive: any effect or state change fails this.
@@ -909,9 +1187,9 @@ struct HydrateTests {
     let firstIDs = store.state.transcript.ids
     let firstStreamingID = store.state.streamingRowID
 
-    // Second hydrate of the SAME running turn (e.g. a foreground/reconnect re-resume).
+    // Second hydrate of the SAME running turn (a foreground re-resume; the socket is
+    // healthy — `status == .ready` — so `.foreground` hydrates directly, no redial).
     await store.send(.foreground)
-    await store.receive(\.gatewayEvent)
     await store.receive(\.activateResult.success)
     let secondIDs = store.state.transcript.ids
 

--- a/HermesKit/Tests/HermesKitTests/RowIdentityTests.swift
+++ b/HermesKit/Tests/HermesKitTests/RowIdentityTests.swift
@@ -110,7 +110,7 @@ struct RowIdentityTests {
       $0.transcript[id: uuid(0)]?.kind = .thinking(reasoning: "Planning", status: "Context: 12%", elapsedSeconds: 0, isComplete: false)
     }
     #expect(store.state.thinkingRowID == uuid(0))
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: keepThinkingLast reordering preserves ids
@@ -137,7 +137,7 @@ struct RowIdentityTests {
     #expect(store.state.transcript.last?.id == uuid(0))
     #expect(store.state.transcript.first?.id == uuid(1))
     #expect(store.state.thinkingRowID == uuid(0))
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   // MARK: Live → deterministic reconciliation on hydrate
@@ -190,7 +190,7 @@ struct RowIdentityTests {
     // Exactly one row per logical message — no duplication.
     #expect(store.state.transcript.count == expected.count)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   /// Re-running `reconstructTranscript` over identical history yields byte-identical ids — the
@@ -242,7 +242,7 @@ struct RowIdentityTests {
     if let liveID { #expect(store.state.transcript[id: liveID] == nil) }
     #expect(store.state.transcript.count == 1)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 
   /// A reasoning-only turn (thinking text, no assistant message) keeps the thinking row id
@@ -280,6 +280,6 @@ struct RowIdentityTests {
     #expect(store.state.transcript[id: deterministicThinkingID] != nil)
     #expect(store.state.transcript[id: uuid(0)] == nil)
 
-    await store.send(.onDisappear)
+    await store.send(.teardown)
   }
 }

--- a/HermesKit/Tests/HermesKitTests/SelfHealTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SelfHealTests.swift
@@ -277,16 +277,25 @@ struct SelfHealTests {
   }
 
   @Test func foregroundResumeDisconnectedDoesNotRecreate() async {
-    // Regression guard: a benign socket drop (`.disconnected`) must NOT recreate — it just goes
-    // reconnecting and keeps the stale id (the reconnect re-resumes it).
+    // Regression guard: a benign socket drop (`.disconnected`) must NOT recreate — it goes
+    // reconnecting (status only) and keeps the stale id. The redial belongs to the companion
+    // `.gatewayClosed` backoff (the teardown that resumed this RPC also finishes the event
+    // stream) — an immediate redial here would defeat the backoff.
+    let connectCalls = LockIsolated(0)
     let store = TestStore(initialState: healableState()) { ChatFeature() } withDependencies: {
       $0.uuid = .incrementing
       $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.connect = { @Sendable _, _ in
+        connectCalls.withValue { $0 += 1 }
+        return AsyncStream { _ in }
+      }
     }
     await store.send(.activateResult(.failure(.disconnected))) {
       $0.status = .reconnecting
     }
     #expect(store.state.liveSessionID == "stale-live") // unchanged, no recreate
+    #expect(connectCalls.value == 0) // no immediate redial — `.gatewayClosed` owns it
+    await store.send(.teardown)
   }
 
   // MARK: session.title (rename) self-heal

--- a/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
@@ -538,6 +538,8 @@ struct SessionListFeatureTests {
       $0.seenCounts = ["b": 2]
       $0.archivingIDs = ["a"] // in-flight guard while the PATCH runs
     }
+    // The parent is told FIRST (it tears the live-chat slot down when it matches).
+    await store.receive(\.delegate.sessionArchived)
     // Success clears the transient guard (so the poll resumes) and cancels any stale in-flight
     // fetch — no permanent filter (server now excludes the archived session anyway).
     await store.receive(\.archiveSucceeded) {
@@ -596,6 +598,8 @@ struct SessionListFeatureTests {
       $0.sessions = [Session(id: "b")]
       $0.archivingIDs = ["a"]
     }
+    // The parent notification precedes the PATCH bookkeeping.
+    await store.receive(\.delegate.sessionArchived)
     // Success clears the guard but cancels the in-flight fetch, so its stale response still
     // can't land afterward to resurrect "a".
     await store.receive(\.archiveSucceeded) {
@@ -639,6 +643,8 @@ struct SessionListFeatureTests {
       $0.sessions = [Session(id: "b")]
       $0.archivingIDs = ["a"]
     }
+    // The parent notification fires regardless of the PATCH outcome (the archive was confirmed).
+    await store.receive(\.delegate.sessionArchived)
     // Failure restores the session at its original index (no reload), lifts the guard, sets error.
     await store.receive(\.archiveFailed) {
       $0.sessions = [session, Session(id: "b")]
@@ -681,6 +687,8 @@ struct SessionListFeatureTests {
       $0.seenCounts = ["b": 2]
       $0.archivingIDs = ["a"]
     }
+    // The parent notification fires regardless of the PATCH outcome (the archive was confirmed).
+    await store.receive(\.delegate.sessionArchived)
     // Failure restores the session + pin + seen baseline LOCALLY (no reload), persists them,
     // lifts the guard, and sets the error.
     await store.receive(\.archiveFailed) {

--- a/HermesKit/Tests/HermesKitTests/TestSupport.swift
+++ b/HermesKit/Tests/HermesKitTests/TestSupport.swift
@@ -1,0 +1,17 @@
+import Testing
+
+/// Bounded busy-wait for cross-task spy flags (e.g. a socket stream's `onTermination`
+/// firing on a cancelled effect): yields until `condition()` holds, FAILING the test —
+/// instead of hanging the suite forever — if it never does.
+@MainActor
+func waitUntil(
+  _ condition: () -> Bool,
+  _ comment: Comment? = nil,
+  sourceLocation: SourceLocation = #_sourceLocation
+) async {
+  for _ in 0..<100_000 {
+    if condition() { return }
+    await Task.yield()
+  }
+  #expect(condition(), comment ?? "Timed out waiting for condition", sourceLocation: sourceLocation)
+}

--- a/HermesMobile/Sources/AppView.swift
+++ b/HermesMobile/Sources/AppView.swift
@@ -27,8 +27,13 @@ struct AppView: View {
     if let homeStore = store.scope(state: \.home, action: \.home) {
       NavigationStack(path: $store.scope(state: \.path, action: \.path)) {
         SessionListView(store: homeStore)
-      } destination: { chatStore in
-        ChatView(store: chatStore)
+      } destination: { _ in
+        // The path holds only thin session-key markers — the REAL chat state lives in the
+        // app-level live-chat slot, so a running turn's socket survives pops. Defensive
+        // empty view if the slot is missing (e.g. cleared mid-pop).
+        if let chatStore = store.scope(state: \.liveChat, action: \.liveChat) {
+          ChatView(store: chatStore)
+        }
       }
     } else if store.autoConnecting {
       ProgressView("Connecting…")

--- a/HermesMobile/Sources/AppView.swift
+++ b/HermesMobile/Sources/AppView.swift
@@ -30,9 +30,15 @@ struct AppView: View {
       } destination: { _ in
         // The path holds only thin session-key markers — the REAL chat state lives in the
         // app-level live-chat slot, so a running turn's socket survives pops. Defensive
-        // empty view if the slot is missing (e.g. cleared mid-pop).
+        // empty view if the slot is missing (e.g. after logout mid-pop).
         if let chatStore = store.scope(state: \.liveChat, action: \.liveChat) {
           ChatView(store: chatStore)
+            // The view's disappearance routes through the PARENT (never the scoped child
+            // store): `AppFeature.chatViewDisappeared` guards a nil slot (logout/quit may
+            // have cleared it while the screen was still animating away) and owns the
+            // idle-pop teardown policy — deferred here until the pop animation finished,
+            // so the outgoing screen stays rendered and no action hits an absent child.
+            .onDisappear { store.send(.chatViewDisappeared) }
         }
       }
     } else if store.autoConnecting {

--- a/HermesMobile/Sources/DemoMode.swift
+++ b/HermesMobile/Sources/DemoMode.swift
@@ -106,9 +106,14 @@ enum DemoMode {
     }
   }
 
-  /// A chat scenario needs a home (so the nav stack has a root) plus one pushed chat.
+  /// A chat scenario needs a home (so the nav stack has a root) plus one pushed chat:
+  /// the chat state fills the live-chat slot and the path holds its thin marker.
   private static func chatScenario(_ chat: ChatFeature.State) -> AppFeature.State {
-    AppFeature.State(home: sessionListState, path: StackState([chat]))
+    AppFeature.State(
+      home: sessionListState,
+      path: StackState([ChatScreen.State()]),
+      liveChat: chat
+    )
   }
 
   // MARK: Sessions

--- a/HermesMobile/Sources/DemoMode.swift
+++ b/HermesMobile/Sources/DemoMode.swift
@@ -107,11 +107,12 @@ enum DemoMode {
   }
 
   /// A chat scenario needs a home (so the nav stack has a root) plus one pushed chat:
-  /// the chat state fills the live-chat slot and the path holds its thin marker.
+  /// the chat state fills the live-chat slot and the path holds its thin marker, carrying
+  /// the chat's session key exactly like production's `fillLiveChat`.
   private static func chatScenario(_ chat: ChatFeature.State) -> AppFeature.State {
     AppFeature.State(
       home: sessionListState,
-      path: StackState([ChatScreen.State()]),
+      path: StackState([ChatScreen.State(sessionKey: chat.sessionKey)]),
       liveChat: chat
     )
   }

--- a/HermesMobile/Sources/Features/Chat/ChatView.swift
+++ b/HermesMobile/Sources/Features/Chat/ChatView.swift
@@ -57,7 +57,8 @@ struct ChatView: View {
       Button("Cancel", role: .cancel) { store.send(.cancelRename) }
     }
     .task { store.send(.task) }
-    .onDisappear { store.send(.onDisappear) }
+    // View-only cleanup (mic/voice) — slot teardown is an `AppFeature` policy, not a view event.
+    .onDisappear { store.send(.viewDisappeared) }
     .sheet(item: toolDetailBinding) { row in
       if case let .tool(name, title, _, detail, durationS) = row.kind {
         ToolDetailSheet(name: name, title: title, detail: detail ?? ToolDetail(), durationS: durationS)

--- a/HermesMobile/Sources/Features/Chat/ChatView.swift
+++ b/HermesMobile/Sources/Features/Chat/ChatView.swift
@@ -57,8 +57,10 @@ struct ChatView: View {
       Button("Cancel", role: .cancel) { store.send(.cancelRename) }
     }
     .task { store.send(.task) }
-    // View-only cleanup (mic/voice) — slot teardown is an `AppFeature` policy, not a view event.
-    .onDisappear { store.send(.viewDisappeared) }
+    // NOTE: no `.onDisappear` here — disappearance is observed by the DESTINATION in
+    // `AppView` (`AppFeature.chatViewDisappeared`), which guards a nil slot and forwards
+    // the mic/voice cleanup (`.viewDisappeared`). Slot teardown is an `AppFeature` policy,
+    // not a view event.
     .sheet(item: toolDetailBinding) { row in
       if case let .tool(name, title, _, detail, durationS) = row.kind {
         ToolDetailSheet(name: name, title: title, detail: detail ?? ToolDetail(), durationS: durationS)

--- a/Project.swift
+++ b/Project.swift
@@ -77,7 +77,7 @@ let project = Project(
           "DEVELOPMENT_TEAM": .string(developmentTeam),
           "CODE_SIGN_STYLE": "Automatic",
           "MARKETING_VERSION": "1.0",
-          "CURRENT_PROJECT_VERSION": "45",
+          "CURRENT_PROJECT_VERSION": "46",
           // Production default (App Store / external TestFlight) — the orange "AppIcon".
           // Debug builds override to the blue "AppIconDev" below. INTERNAL TestFlight
           // archives the Release config but overrides the icon on the xcodebuild command

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ from your desk and still keep your agent moving.
   when the link drops. Reopening a session — after navigating away, backgrounding the app,
   or a cold relaunch — restores its live state: the right model, context usage, full
   tool/thinking history, and an in-progress turn that keeps streaming with its timer ticking.
+  A running turn even keeps its live connection while you browse the session list, and for a
+  short grace window after backgrounding — falling back to reconnect-and-restore beyond that.
 - **Get pinged when it needs you.** Opt in to push notifications and the agent can ping
   your phone — even when the app is closed — when it needs an approval, asks you to
   clarify, finishes a longer turn, or hits an error. This rides a three-part

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,11 @@ approval/clarify requests).
 
 ```
 AppFeature                 // root nav + launch auto-connect; onboarding until connected;
-│                          //   presents ReauthFeature on .sessionExpired (identity-aware routing)
+│                          //   presents ReauthFeature on .sessionExpired (identity-aware routing);
+│                          //   owns the LIVE-CHAT SLOT (liveChat: ChatFeature.State? via .ifLet)
+│                          //   and a nav path of thin ChatScreen markers — slot teardown (idle
+│                          //   pop, detached turn end, replacement, archive, logout) is
+│                          //   AppFeature policy, never a view event
 ├─ ConnectionFeature       // auto-validating URL + capability-aware auth toggle (Password | Token)
 ├─ ReauthFeature           // re-auth modal: fixed URL, prefilled identity, password/token field;
 │                          //   same-user resume vs different-user switch vs Quit→onboarding
@@ -36,9 +40,13 @@ AppFeature                 // root nav + launch auto-connect; onboarding until c
 │  ├─ SettingsFeature      // token mgmt, manual reconnect, debug log
 │  ├─ ArchivedSessionsFeature // archived list (?archived=only); restore + open delegate
 │  └─ AddProfileFeature    // create-then-PUT-soul; inline name validation + server-400 banner
-└─ ChatFeature             // owns the WS lifecycle + streaming reduction; also folds in
-                           //   approvals, clarify/sudo/secret, the tool-detail sheet,
-                           //   and the model/reasoning picker, reconnect
+├─ ChatScreen              // navigation-path marker ONLY (session key, no behavior) — pushing/
+│                          //   popping it never creates or destroys chat state
+└─ ChatFeature             // SLOT-rooted (composed via .ifLet, NOT a path element), so a running
+                           //   turn's socket + streaming effects survive nav pops; owns the WS
+                           //   lifecycle + streaming reduction; also folds in approvals,
+                           //   clarify/sudo/secret, the tool-detail sheet, the model/reasoning
+                           //   picker, reconnect
 ```
 
 ## Dependency clients
@@ -86,6 +94,13 @@ a `testValue`/`.inMemory()` variant):
   `testValue`, plus an `.inMemory()` variant. Pure helpers (hex encoding, the compile-time
   `apnsEnv`, payload parsing, foreground-suppression decision) live outside the guard so they
   are unit-tested on macOS.
+- **`BackgroundTaskClient`** — a finite background-execution window (~30s) wrapping
+  `UIApplication.beginBackgroundTask`/`endBackgroundTask`: `begin(name) → AsyncStream<Void>`
+  yields exactly once if iOS expires the window early (then finishes; a normal end finishes
+  without a yield), `end()` is idempotent. The client owns the mandatory end-on-expiry
+  bookkeeping (every begun task is ended exactly once — explicitly, by replacement, or inside
+  the generation-scoped expiration handler). `liveValue` is `#if canImport(UIKit)`-guarded
+  (no-op elsewhere); `.inMemory()` exposes a test-drivable `expire()` plus begin/end spies.
 - **`PasteboardClient`** — copy.
 - **`DebugLogClient`** — an event ring buffer for the in-app debug log.
 
@@ -257,10 +272,25 @@ response (`applyActivate`), in order:
    it.
 
 App lifecycle (`scenePhase`, observed in the SwiftUI shell and dispatched as
-`AppFeature.scenePhaseChanged`) routes `.active` into the open chat's `.foreground` (reconnect +
-re-hydrate via `session.resume`) plus a session-list refresh, and `.background`/`.inactive` into an immediate
-snapshot/anchor flush. The nav stack is **not** auto-restored on cold launch — opening a session
-is enough.
+`AppFeature.scenePhaseChanged`): `.active` ends any background grace task, then routes the live
+chat's `.foreground` (re-hydrate via `session.resume`; the socket reconnects **only if it isn't
+`.ready`** — a healthy one is never cancel-and-redialed) plus an immediate session-list refresh.
+`.inactive` (transient occlusion) is an immediate snapshot/anchor flush only. `.background`
+flushes too, and — when a turn is RUNNING — additionally begins a finite ~30s
+`BackgroundTaskClient` window so the socket simply keeps streaming past suspension. If iOS
+expires that window while still backgrounded: one final flush, then a clean socket-only
+disconnect (`.teardownSocketOnly`) that keeps the chat state in memory, so the next foreground
+hydrate re-attaches with the #26 live-row preservation; catch-up beyond that is the existing
+push + reconnect path. An idle chat backgrounds with no task (no battery burn), and a stale
+expiry that races `.active` is guarded to a no-op. The nav stack is **not** auto-restored on
+cold launch — opening a session is enough.
+
+Navigation shares the same keep-alive policy (#33): the open chat's state lives in the
+`AppFeature`-owned slot (`liveChat`), and the navigation path holds only thin `ChatScreen`
+session-key markers — popping to the list destroys nothing while a turn runs (the socket
+streams on detached, and re-opening re-attaches via `.reattached` without redialing a healthy
+socket); an idle chat is torn down only after the pop animation finishes (the destination's
+disappearance routes through `AppFeature.chatViewDisappeared`).
 
 The session-list **working glow** is driven event-driven by `ChatFeature.Delegate.runningChanged`
 (emitted on `message.start`/`complete`/`error` and from the `session.resume` `running` flag),

--- a/docs/plans/20260716-keep-running-session-alive.md
+++ b/docs/plans/20260716-keep-running-session-alive.md
@@ -235,11 +235,11 @@ struct BackgroundTaskClient {
 - Create: `HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift`
 - Create: `HermesKit/Tests/HermesKitTests/BackgroundTaskClientTests.swift`
 
-- [ ] implement the `@DependencyClient` (`begin(name) -> AsyncStream<Void>` yielding once on early expiry; `end()`), `DependencyValues` registration
-- [ ] `#if canImport(UIKit)` liveValue wrapping `beginBackgroundTask`/`endBackgroundTask` with internal end-on-expiry bookkeeping; non-iOS `liveValue = testValue`
-- [ ] in-memory `testValue` with a test-drivable expiry trigger (continuation captured for tests), `AudioRecorderClient` pattern
-- [ ] write tests: begin/end bookkeeping; expiry yields exactly once; double-begin replaces the prior task
-- [ ] run tests — must pass before task 5
+- [x] implement the `@DependencyClient` (`begin(name) -> AsyncStream<Void>` yielding once on early expiry; `end()`), `DependencyValues` registration
+- [x] `#if canImport(UIKit)` liveValue wrapping `beginBackgroundTask`/`endBackgroundTask` with internal end-on-expiry bookkeeping; non-iOS `liveValue = testValue`
+- [x] in-memory `testValue` with a test-drivable expiry trigger (continuation captured for tests), `AudioRecorderClient` pattern
+- [x] write tests: begin/end bookkeeping; expiry yields exactly once; double-begin replaces the prior task
+- [x] run tests — must pass before task 5
 
 ### Task 5: Background grace policy in scenePhaseChanged
 
@@ -247,12 +247,12 @@ struct BackgroundTaskClient {
 - Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 
-- [ ] `.background` with `liveChat` running: `persistNow` + start the background task effect (cancellable `CancelID.backgroundGrace`), listening for expiry
-- [ ] on expiry while still backgrounded: final `persistNow`, cancel the socket only (`.teardownSocketOnly` — keep `liveChat` state in memory for #26 preservation), `end()` the task
-- [ ] `.active`: cancel the grace effect + `end()` the task; existing `.foreground` fan-out (now to `liveChat` directly, no top-of-path hunting) unchanged
-- [ ] `.background` with idle/no slot: `persistNow` only, no task
-- [ ] write tests (TestClock + fake BackgroundTaskClient): running → task begun + socket alive through the window; expiry → persist + socket cancelled + state retained; active-before-expiry → task ended, no socket cancel; idle → no task
-- [ ] run tests — must pass before task 6
+- [x] `.background` with `liveChat` running: `persistNow` + start the background task effect (cancellable `CancelID.backgroundGrace`), listening for expiry
+- [x] on expiry while still backgrounded: final `persistNow`, cancel the socket only (`.teardownSocketOnly` — keep `liveChat` state in memory for #26 preservation), `end()` the task
+- [x] `.active`: cancel the grace effect + `end()` the task; existing `.foreground` fan-out (now to `liveChat` directly, no top-of-path hunting) unchanged
+- [x] `.background` with idle/no slot: `persistNow` only, no task
+- [x] write tests (TestClock + fake BackgroundTaskClient): running → task begun + socket alive through the window; expiry → persist + socket cancelled + state retained; active-before-expiry → task ended, no socket cancel; idle → no task
+- [x] run tests — must pass before task 6
 
 ### Task 6: Push-tap routing dedup (closes #32)
 

--- a/docs/plans/20260716-keep-running-session-alive.md
+++ b/docs/plans/20260716-keep-running-session-alive.md
@@ -1,0 +1,292 @@
+# Keep Running Session Alive Across Navigation and Backgrounding
+
+## Overview
+
+Today the gateway socket's lifetime equals the pushed `ChatFeature`'s lifetime: popping
+chat → sessions list destroys the state (`path: StackState<ChatFeature.State>` element
+removal) and cancels the socket, discarding live thinking/tool/streaming rows; and
+backgrounding suspends the process with no grace period, killing the socket mid-turn.
+Reasoning/tool events streamed while disconnected are unrecoverable client-side (the
+server's `inflight` carries only user/assistant text; there is no replay buffer).
+
+This plan makes a **running turn keep its socket**:
+
+1. **Nav-pop** — lift the open chat's state into an `AppFeature`-owned "live chat slot"
+   (`liveChat: ChatFeature.State?`); the navigation path holds only thin session-id
+   markers. Popping to the list no longer cancels anything — the turn keeps streaming,
+   rows accumulate, and re-opening re-attaches live.
+2. **Backgrounding** — a new `BackgroundTaskClient` (`beginBackgroundTask`) keeps the
+   socket alive ~30s after `.background`; then flush + clean disconnect, falling back to
+   the existing push + reconnect + hydrate catch-up.
+3. **Push-tap dedup** (closes #32) — tap routing compares the pushed `session_id`
+   against the slot + path, so tapping a push for the already-open session no longer
+   stacks a duplicate chat screen.
+
+Resolves the issue #33 spike (decision: client-only, no background modes, no
+`BGTaskScheduler`) and closes #32.
+
+## Context (from discovery)
+
+- `HermesKit/Sources/HermesKit/AppFeature.swift` — `path: StackState<ChatFeature.State>`
+  (:11), `currentViewingSessionID` (:43-45), `scenePhaseChanged` (:141-158, top-of-path
+  hunting), `pushTapped` (:160-179, always appends via `openSession`), `openSession`
+  (:185-202), `createSession` (:204-215), disconnect/logout (:217-223, :246-257),
+  `sessionExpired` reads `path.last` (:225-231), reauth resume targets `path.ids.last`
+  (:233-244), `runningChanged` routing (:259-264), `.forEach(\.path)` (:276-278),
+  `.onChange(of: \.currentViewingSessionID)` (:283-287).
+- `HermesKit/Sources/HermesKit/Features/ChatFeature.swift` — `.task` → `connect` (:357-363),
+  `.onDisappear` kill-everything (:365-379, also releases the mic), `.gatewayClosed`
+  backoff (:406-424), `.reconnectTick` (:426-427), `.resumeAfterReauth` (:429-440),
+  `.persistNow` (:493-502), `.foreground` (:504-516, resets `hasRequestedSession` +
+  reconnects unconditionally), `connect` (~:1302, `CancelID.socket`, `cancelInFlight: true`),
+  `hydrate` (~:1346), `applyActivate` + #26 live-row preservation (~:1373-1494),
+  `status` (`.ready`/`.reconnecting`) is the connection-alive signal.
+- `HermesMobile/Sources/AppView.swift` — `NavigationStack(path: $store.scope(...))`
+  destination builds `ChatView(store: chatStore)` from the path element (:28-32);
+  scenePhase observer (:20-22).
+- `HermesMobile/Sources/Features/Chat/` — `ChatView.onDisappear` sends `.onDisappear`.
+- Pattern references: `AudioRecorderClient.swift` (UIKit-guarded client),
+  `PushClient.swift`, `PreferencesClient.swift`.
+- Related history: state-sync plan (#18) made hydrate server-authoritative; #26 preserves
+  live thinking/tool rows on foreground re-hydrate but only while the ChatFeature is
+  still alive — the slot makes that always true.
+
+## Locked decisions (from brainstorm — do not re-open)
+
+- Client-only; **no hermes-agent changes**.
+- Background bar: **~30s grace then catch-up**. No audio/VoIP/processing background
+  modes, no `BGTaskScheduler` reconnect.
+- Approach: **live chat slot in `AppFeature`** (one live session at a time; opening a
+  different session replaces the slot, same as today — no regression).
+- Slot policy: a running turn keeps its socket; an idle chat doesn't need one.
+- Reauth surfaces at root even while detached; slot sits paused until resolved.
+
+## Development Approach
+
+- **Testing approach: Regular** (implementation, then tests within the same task).
+- Complete each task fully before moving to the next; small focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for its code changes —
+  success and error scenarios; `TestStore` + `@Dependency` overrides + `TestClock`.
+- **CRITICAL: all tests must pass before starting the next task.**
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Per-task commits (capitalized verb, no conventional-commit prefixes). Skip the codex
+  external-review phase.
+- `script -q /dev/null swift test --package-path HermesKit` for live test output.
+- New app-target source files need `tuist generate` before an `xcodebuild` build.
+
+## Testing Strategy
+
+- **Unit tests** (HermesKit `swift test`): AppFeature slot-policy suite is the core new
+  coverage; ChatFeature's existing suite stays green with minimal churn (actions renamed
+  where noted).
+- **Snapshot tests** (`make snapshot`): no visual changes expected; run to confirm. If a
+  snapshot host constructs `AppFeature.State.path` with `ChatFeature.State`, update it to
+  the marker + slot shape.
+
+## Progress Tracking
+
+- Mark completed items with `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix; blockers with ⚠️ prefix.
+- Keep the plan in sync with actual work.
+
+## Solution Overview
+
+```swift
+// AppFeature.State — after
+public var path: StackState<ChatScreen.State>   // thin marker: session key only
+public var liveChat: ChatFeature.State?          // the real chat state, slot-owned
+```
+
+- `liveChat` composed with `.ifLet(\.liveChat, action: \.liveChat)` — the socket,
+  reconnect backoff, thinking ticker, and debounced persist become slot-rooted and
+  survive navigation.
+- The navigation destination scopes into `store.liveChat` (defensive `EmptyView` if nil).
+- Teardown becomes an explicit `AppFeature` policy (new `ChatFeature` action
+  `.teardown` = today's kill-everything `.onDisappear`); the view's disappear action
+  shrinks to mic/voice cleanup only.
+
+### Lifecycle rules
+
+| Event | Policy |
+| --- | --- |
+| Open session (slot empty) | Fill slot + push marker; connect + hydrate as today |
+| Open different session (slot occupied) | `persistNow` + `.teardown` old → replace slot + set path |
+| Re-open the slot's session | Push marker only; `.reattached` (hydrate; connect only if socket dead) |
+| Pop, turn running | Keep slot untouched (socket streams, list glow via `runningChanged`) |
+| Pop, idle | `persistNow` + `.teardown` → `liveChat = nil` |
+| Turn completes/errors while detached | Flush persist → tear down immediately |
+| Archive the slot's session from the list | Tear slot down first, then today's optimistic archive |
+| Logout / identity switch | Clear slot unconditionally (with existing wipes) |
+| `.sessionExpired` (attached or detached) | Raise `ReauthFeature` at root; slot paused; same-user resume re-attaches |
+
+### Backgrounding
+
+- `.background` with `liveChat` running: `persistNow` + `backgroundTask.begin` — the
+  socket just keeps running (no `ChatFeature` changes).
+- Expiry (~30s, still backgrounded): final `persistNow`, cancel the socket cleanly
+  (`.teardownSocketOnly` — state stays in memory), end the task. Catch-up is then the
+  existing push + `.foreground` reconnect/hydrate with #26 preservation (now always
+  applicable since the state survived).
+- `.active` before expiry: end the task; existing `.foreground` path runs harmlessly.
+- `.background` with no running turn: `persistNow` only — no task, no battery burn.
+
+### Re-attach connect guard (key subtlety)
+
+Re-opening a live slot must **not** cancel-and-redial a healthy socket (the gap drops
+events). New `ChatFeature.Action.reattached`: always re-hydrate (server authority, the
+existing #26-safe `applyActivate` path), but `connect` only when the socket isn't alive
+(`status != .ready` — else just reset `hasRequestedSession` and invoke the hydrate
+effect directly against the live socket).
+
+### Push-tap routing (closes #32)
+
+Decided in `AppFeature.pushTapped` by comparing `tap.sessionID` to the slot + path:
+
+- matches slot **and** its marker is on top of the path → **no navigation**; in-place
+  hydrate covers the update (badge bookkeeping still runs).
+- matches slot, user on the list (no marker) → push the marker (live re-attach, no dup).
+- different session → replace the slot and **set** the path to the single new marker
+  (no stacking on cold launch either).
+
+## Technical Details
+
+- `ChatScreen` — a minimal `@Reducer` (or plain identified state) whose `State` holds the
+  session key (`storedSessionID ?? liveSessionID` at push time; a new chat uses a stable
+  placeholder id until resolved). No behavior of its own.
+- `currentViewingSessionID` becomes: top marker present → `liveChat`'s session key,
+  else `nil` (semantics preserved: detached-on-list means pushes for that session are
+  not suppressed).
+- Pop detection: handle `.path(.popFrom)` / observe path emptiness via `.onChange(of: \.path)`
+  in `AppFeature` — whichever proves reliable with the marker stack; the policy branch
+  (`liveChat.isRunning`?) is what's tested.
+- `ChatFeature` gains a lightweight `isRunning`-style accessor if one doesn't exist
+  (drive off the same state that powers `runningChanged`).
+- `BackgroundTaskClient`:
+
+```swift
+@DependencyClient
+struct BackgroundTaskClient {
+  /// Starts a finite background task; the stream yields once if iOS expires it early.
+  var begin: @Sendable (_ name: String) async -> AsyncStream<Void> = { _ in .finished }
+  var end: @Sendable () async -> Void
+}
+```
+
+  `#if canImport(UIKit)` `liveValue` wrapping `UIApplication.beginBackgroundTask`/
+  `endBackgroundTask` (the client owns the mandatory end-on-expiry bookkeeping);
+  non-iOS `liveValue = testValue`; in-memory `testValue` with test-drivable expiry
+  (mirrors `AudioRecorderClient`). Lives in `HermesMobile/Sources/Features` alongside the
+  other clients? — **No**: clients live in `HermesKit/Sources/HermesKit/Clients/`
+  (`PushClient.swift` pattern); put it there so `AppFeature` can depend on it and tests run
+  under `swift test`.
+
+## Implementation Steps
+
+### Task 1: Introduce the live chat slot and marker navigation path
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+- Create: `HermesKit/Sources/HermesKit/Features/ChatScreen.swift`
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesMobile/Sources/AppView.swift`
+- Modify: `HermesMobile/Sources/Features/Chat/ChatView.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift` (+ any test/snapshot host constructing `path`)
+
+- [ ] add `ChatScreen.State` (session-key marker) and switch `AppFeature.State.path` to `StackState<ChatScreen.State>`; add `liveChat: ChatFeature.State?` + `.ifLet(\.liveChat, action: \.liveChat)`; update `currentViewingSessionID`
+- [ ] rewire `openSession`/`createSession` to fill the slot and push a marker; rewire `sessionExpired`/`resumeAfterReauth`/`runningChanged`/logout paths from `path.last`/`path.ids.last` to `liveChat`
+- [ ] split `ChatFeature.onDisappear` into `.viewDisappeared` (mic/voice cleanup only) and `.teardown` (persist + full cancel of socket/reconnect/thinking/persist effects); `ChatView` sends the former
+- [ ] update `AppView` destination to scope `store.liveChat` into `ChatView` (defensive empty view when nil); keep behavior byte-identical for the plain open→pop-idle flow (pop while idle tears down via the Task 2 policy — for this task, wire pop→teardown unconditionally so no socket leaks between tasks)
+- [ ] write/adjust AppFeature tests: open fills slot + pushes marker; logout clears slot; reauth resume targets `liveChat`; existing suites green
+- [ ] run tests — must pass before task 2
+
+### Task 2: Slot lifecycle policy (keep-while-running, teardown rules)
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+- Modify: `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift` (archived delegate)
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+
+- [ ] on pop (`.path(.popFrom)` / path-emptied): keep the slot untouched when `liveChat.isRunning`; otherwise `persistNow` + `.teardown` + `liveChat = nil`
+- [ ] on `runningChanged(running: false)` (and error/interrupt completions) while no marker is in the path: flush persist then tear the slot down
+- [ ] on open-different-session while the slot is occupied: `persistNow` + `.teardown` the old slot before filling the new one
+- [ ] surface a `sessionArchived(id)` delegate from `SessionListFeature` and tear the slot down first when it matches the slot's session
+- [ ] write tests: pop-while-running keeps effects alive (streaming event after pop still mutates `liveChat`); idle pop tears down; complete-while-detached tears down; slot replacement persists + cancels the old chat; archive-the-slot-session tears down
+- [ ] run tests — must pass before task 3
+
+### Task 3: Re-attach flow with the connect guard
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+
+- [ ] add `ChatFeature.Action.reattached`: socket alive (`status == .ready` with a live session) → re-run the hydrate effect directly (no reconnect); socket dead → behave like `.foreground` (reset `hasRequestedSession`, `connect`)
+- [ ] `AppFeature`: re-opening the slot's session pushes the marker only and sends `.liveChat(.reattached)` (no new `ChatFeature.State`, no re-init losing live rows)
+- [ ] make `ChatView.task` re-attach-safe: appearance of an already-connected slot must not fire the unconditional `connect` (route the view's task through `.reattached` or gate `.task` on slot freshness)
+- [ ] write tests: reattach with a live socket does NOT cancel/redial (no `.gatewayClosed`, streaming continues) but does hydrate; reattach with a dead socket reconnects; re-open keeps accumulated detached rows
+- [ ] run tests — must pass before task 4
+
+### Task 4: BackgroundTaskClient
+
+**Files:**
+- Create: `HermesKit/Sources/HermesKit/Clients/BackgroundTaskClient.swift`
+- Create: `HermesKit/Tests/HermesKitTests/BackgroundTaskClientTests.swift`
+
+- [ ] implement the `@DependencyClient` (`begin(name) -> AsyncStream<Void>` yielding once on early expiry; `end()`), `DependencyValues` registration
+- [ ] `#if canImport(UIKit)` liveValue wrapping `beginBackgroundTask`/`endBackgroundTask` with internal end-on-expiry bookkeeping; non-iOS `liveValue = testValue`
+- [ ] in-memory `testValue` with a test-drivable expiry trigger (continuation captured for tests), `AudioRecorderClient` pattern
+- [ ] write tests: begin/end bookkeeping; expiry yields exactly once; double-begin replaces the prior task
+- [ ] run tests — must pass before task 5
+
+### Task 5: Background grace policy in scenePhaseChanged
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+
+- [ ] `.background` with `liveChat` running: `persistNow` + start the background task effect (cancellable `CancelID.backgroundGrace`), listening for expiry
+- [ ] on expiry while still backgrounded: final `persistNow`, cancel the socket only (`.teardownSocketOnly` — keep `liveChat` state in memory for #26 preservation), `end()` the task
+- [ ] `.active`: cancel the grace effect + `end()` the task; existing `.foreground` fan-out (now to `liveChat` directly, no top-of-path hunting) unchanged
+- [ ] `.background` with idle/no slot: `persistNow` only, no task
+- [ ] write tests (TestClock + fake BackgroundTaskClient): running → task begun + socket alive through the window; expiry → persist + socket cancelled + state retained; active-before-expiry → task ended, no socket cancel; idle → no task
+- [ ] run tests — must pass before task 6
+
+### Task 6: Push-tap routing dedup (closes #32)
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+
+- [ ] route `pushTapped` by slot/path comparison: matches slot + marker on top → no path change (badge bookkeeping only); matches slot + on list → push marker + `.reattached`; different → replace slot + SET path to the single new marker
+- [ ] keep cold-launch behavior correct (no home yet → badge only, as today)
+- [ ] write tests: matching id with chat open → no path change; matching id from list → re-attach push, no duplicate; different id → slot replaced, path set (not appended); approval badge bookkeeping preserved
+- [ ] run tests — must pass before task 7
+
+### Task 7: Verify acceptance criteria
+
+- [ ] pop during a streaming turn → return: no lost thinking/tool rows, timer continuous, no reconnect flash (manual sim run + reducer assertions)
+- [ ] all lifecycle rules from Solution Overview covered by a passing test each
+- [ ] run full suite: `script -q /dev/null swift test --package-path HermesKit`
+- [ ] `tuist generate` + app build; run `make snapshot` — update hosts if the path shape broke them, confirm no visual diffs
+- [ ] verify no socket leak: teardown paths cancel `CancelID.socket` exactly once (instrument via test gateway client)
+
+### Task 8: Update documentation and close out
+
+- [ ] update `CLAUDE.md` conventions: the live-chat-slot ownership rule, BackgroundTaskClient, push-tap dedup routing
+- [ ] update `README.md` if the feature list mentions lifecycle behavior
+- [ ] post the #33 write-up comment (decision: 30s grace + slot; no background modes) and reference this plan; note #32 is fixed
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification:**
+- Device test: background mid-turn < 30s → return: streaming never dropped (watch for the reconnect status flash — there should be none).
+- Device test: background > 30s → push arrives on completion; foreground → hydrate with preserved thinking/tool rows.
+- Device test: pop to list mid-turn, watch the row glow, re-open → live re-attach.
+- Battery sanity: idle backgrounding starts no background task (Xcode Energy gauge).
+
+**External follow-ups:**
+- Close #32 and #33 on GitHub after merge (#33 gets the decision write-up comment).
+- Server-side replay buffer for reasoning/tool events missed while disconnected remains
+  an upstream gap (related: #30 re-surfacing pending approvals) — out of scope here.

--- a/docs/plans/20260716-keep-running-session-alive.md
+++ b/docs/plans/20260716-keep-running-session-alive.md
@@ -192,12 +192,14 @@ struct BackgroundTaskClient {
 - Modify: `HermesMobile/Sources/Features/Chat/ChatView.swift`
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift` (+ any test/snapshot host constructing `path`)
 
-- [ ] add `ChatScreen.State` (session-key marker) and switch `AppFeature.State.path` to `StackState<ChatScreen.State>`; add `liveChat: ChatFeature.State?` + `.ifLet(\.liveChat, action: \.liveChat)`; update `currentViewingSessionID`
-- [ ] rewire `openSession`/`createSession` to fill the slot and push a marker; rewire `sessionExpired`/`resumeAfterReauth`/`runningChanged`/logout paths from `path.last`/`path.ids.last` to `liveChat`
-- [ ] split `ChatFeature.onDisappear` into `.viewDisappeared` (mic/voice cleanup only) and `.teardown` (persist + full cancel of socket/reconnect/thinking/persist effects); `ChatView` sends the former
-- [ ] update `AppView` destination to scope `store.liveChat` into `ChatView` (defensive empty view when nil); keep behavior byte-identical for the plain open→pop-idle flow (pop while idle tears down via the Task 2 policy — for this task, wire pop→teardown unconditionally so no socket leaks between tasks)
-- [ ] write/adjust AppFeature tests: open fills slot + pushes marker; logout clears slot; reauth resume targets `liveChat`; existing suites green
-- [ ] run tests — must pass before task 2
+- [x] add `ChatScreen.State` (session-key marker) and switch `AppFeature.State.path` to `StackState<ChatScreen.State>`; add `liveChat: ChatFeature.State?` + `.ifLet(\.liveChat, action: \.liveChat)`; update `currentViewingSessionID`
+- [x] rewire `openSession`/`createSession` to fill the slot and push a marker; rewire `sessionExpired`/`resumeAfterReauth`/`runningChanged`/logout paths from `path.last`/`path.ids.last` to `liveChat`
+- [x] split `ChatFeature.onDisappear` into `.viewDisappeared` (mic/voice cleanup only) and `.teardown` (full cancel of socket/reconnect/thinking/persist effects; the snapshot flush is `AppFeature`'s `.persistNow`-before-`.teardown` sequence on pop, matching the lifecycle table); `ChatView` sends the former
+- [x] update `AppView` destination to scope `store.liveChat` into `ChatView` (defensive empty view when nil); keep behavior byte-identical for the plain open→pop-idle flow (pop while idle tears down via the Task 2 policy — for this task, wire pop→teardown unconditionally so no socket leaks between tasks)
+- [x] write/adjust AppFeature tests: open fills slot + pushes marker; logout clears slot; reauth resume targets `liveChat`; existing suites green
+- [x] run tests — must pass before task 2
+- ➕ [x] open-different-session while the slot is occupied already tears the old slot down in Task 1 (concatenated `.teardown` → `.fillLiveChat`): slot cancel IDs are position-scoped, so a leaked old socket would feed events into the replacement state. Task 2 adds `persistNow` to that sequence.
+- ➕ [x] one slot ↔ one marker: `fillLiveChat` resets the path (removeAll + append) instead of appending, so duplicate markers can never stack; Task 6 still adds the same-session routing compare.
 
 ### Task 2: Slot lifecycle policy (keep-while-running, teardown rules)
 
@@ -206,12 +208,12 @@ struct BackgroundTaskClient {
 - Modify: `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift` (archived delegate)
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 
-- [ ] on pop (`.path(.popFrom)` / path-emptied): keep the slot untouched when `liveChat.isRunning`; otherwise `persistNow` + `.teardown` + `liveChat = nil`
-- [ ] on `runningChanged(running: false)` (and error/interrupt completions) while no marker is in the path: flush persist then tear the slot down
-- [ ] on open-different-session while the slot is occupied: `persistNow` + `.teardown` the old slot before filling the new one
-- [ ] surface a `sessionArchived(id)` delegate from `SessionListFeature` and tear the slot down first when it matches the slot's session
-- [ ] write tests: pop-while-running keeps effects alive (streaming event after pop still mutates `liveChat`); idle pop tears down; complete-while-detached tears down; slot replacement persists + cancels the old chat; archive-the-slot-session tears down
-- [ ] run tests — must pass before task 3
+- [x] on pop (`.path(.popFrom)` / path-emptied): keep the slot untouched when `liveChat.isRunning`; otherwise `persistNow` + `.teardown` + `liveChat = nil`
+- [x] on `runningChanged(running: false)` (and error/interrupt completions) while no marker is in the path: flush persist then tear the slot down
+- [x] on open-different-session while the slot is occupied: `persistNow` + `.teardown` the old slot before filling the new one
+- [x] surface a `sessionArchived(id)` delegate from `SessionListFeature` and tear the slot down first when it matches the slot's session
+- [x] write tests: pop-while-running keeps effects alive (streaming event after pop still mutates `liveChat`); idle pop tears down; complete-while-detached tears down; slot replacement persists + cancels the old chat; archive-the-slot-session tears down
+- [x] run tests — must pass before task 3
 
 ### Task 3: Re-attach flow with the connect guard
 
@@ -221,11 +223,11 @@ struct BackgroundTaskClient {
 - Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 
-- [ ] add `ChatFeature.Action.reattached`: socket alive (`status == .ready` with a live session) → re-run the hydrate effect directly (no reconnect); socket dead → behave like `.foreground` (reset `hasRequestedSession`, `connect`)
-- [ ] `AppFeature`: re-opening the slot's session pushes the marker only and sends `.liveChat(.reattached)` (no new `ChatFeature.State`, no re-init losing live rows)
-- [ ] make `ChatView.task` re-attach-safe: appearance of an already-connected slot must not fire the unconditional `connect` (route the view's task through `.reattached` or gate `.task` on slot freshness)
-- [ ] write tests: reattach with a live socket does NOT cancel/redial (no `.gatewayClosed`, streaming continues) but does hydrate; reattach with a dead socket reconnects; re-open keeps accumulated detached rows
-- [ ] run tests — must pass before task 4
+- [x] add `ChatFeature.Action.reattached`: socket alive (`status == .ready` with a live session) → re-run the hydrate effect directly (no reconnect); socket dead → behave like `.foreground` (reset `hasRequestedSession`, `connect`)
+- [x] `AppFeature`: re-opening the slot's session pushes the marker only and sends `.liveChat(.reattached)` (no new `ChatFeature.State`, no re-init losing live rows)
+- [x] make `ChatView.task` re-attach-safe: appearance of an already-connected slot must not fire the unconditional `connect` (gated `.task` on slot freshness via a new internal `hasStarted` flag — first appearance connects, later appearances no-op and `.reattached` owns re-opens; `ChatView` unchanged)
+- [x] write tests: reattach with a live socket does NOT cancel/redial (no `.gatewayClosed`, streaming continues) but does hydrate; reattach with a dead socket reconnects; re-open keeps accumulated detached rows
+- [x] run tests — must pass before task 4
 
 ### Task 4: BackgroundTaskClient
 

--- a/docs/plans/20260716-keep-running-session-alive.md
+++ b/docs/plans/20260716-keep-running-session-alive.md
@@ -267,11 +267,11 @@ struct BackgroundTaskClient {
 
 ### Task 7: Verify acceptance criteria
 
-- [ ] pop during a streaming turn → return: no lost thinking/tool rows, timer continuous, no reconnect flash (manual sim run + reducer assertions)
-- [ ] all lifecycle rules from Solution Overview covered by a passing test each
-- [ ] run full suite: `script -q /dev/null swift test --package-path HermesKit`
-- [ ] `tuist generate` + app build; run `make snapshot` — update hosts if the path shape broke them, confirm no visual diffs
-- [ ] verify no socket leak: teardown paths cancel `CancelID.socket` exactly once (instrument via test gateway client)
+- [x] pop during a streaming turn → return: no lost thinking/tool rows, timer continuous, no reconnect flash — reducer assertions: `popWhileRunningKeepsSlotAndKeepsStreaming` (strengthened: `messageStart` ticker + debounced persist keep firing across the pop, thinking row kept, fold alive) + `reopeningSlotSessionReattachesKeepingDetachedRows` / `reattachWithLiveSocketHydratesWithoutRedial` (zero redials = no reconnect flash). Manual sim run deferred to Post-Completion (not automatable here)
+- [x] all lifecycle rules from Solution Overview covered by a passing test each — audit: open-empty `openingSessionFillsSlotAndPushesMarker`/`creatingSessionFillsSlotWithNewChat`; open-different `openingAnotherSessionReplacesSlotAfterTeardown`; re-open `reopeningSlotSessionReattachesKeepingDetachedRows`; pop-running `popWhileRunningKeepsSlotAndKeepsStreaming`; pop-idle `popTearsDownAndClearsSlot`; end-while-detached `turnEndingWhileDetachedTearsDownSlot`; archive `archivingSlotSessionTearsDownSlot`; logout/identity `disconnectClearsLiveChatSlot`/`differentUserReauthPopsToListAndClearsIdentityPrefs`/`quitFromReauthFullyLogsOutToOnboarding`; sessionExpired `sessionExpiredPresentsReauthModalSeededFromChat`/`sessionExpiredWhileDetachedStillPresentsReauthModal`/`sameUserReauthResumesChatInPlace`
+- [x] run full suite: `script -q /dev/null swift test --package-path HermesKit` — 680 tests in 49 suites passed
+- [x] `tuist generate` + app build (xcodebuild, iOS Simulator — exit 0); `make snapshot` — TEST SUCCEEDED, no host changes needed, no visual diffs
+- [x] verify no socket leak: teardown paths cancel `CancelID.socket` exactly once — new instrumented tests `idlePopCancelsSocketExactlyOnce` + `slotReplacementCancelsOldSocketExactlyOnce` count gateway connects/stream terminations (old socket cancelled exactly once BEFORE the replacement dials, so `cancelInFlight` can't mask a missing teardown)
 
 ### Task 8: Update documentation and close out
 

--- a/docs/plans/20260716-keep-running-session-alive.md
+++ b/docs/plans/20260716-keep-running-session-alive.md
@@ -260,10 +260,10 @@ struct BackgroundTaskClient {
 - Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 
-- [ ] route `pushTapped` by slot/path comparison: matches slot + marker on top → no path change (badge bookkeeping only); matches slot + on list → push marker + `.reattached`; different → replace slot + SET path to the single new marker
-- [ ] keep cold-launch behavior correct (no home yet → badge only, as today)
-- [ ] write tests: matching id with chat open → no path change; matching id from list → re-attach push, no duplicate; different id → slot replaced, path set (not appended); approval badge bookkeeping preserved
-- [ ] run tests — must pass before task 7
+- [x] route `pushTapped` by slot/path comparison: matches slot + marker on top → no path change (badge bookkeeping only); matches slot + on list → push marker + `.reattached`; different → replace slot + SET path to the single new marker
+- [x] keep cold-launch behavior correct (no home yet → badge only, as today)
+- [x] write tests: matching id with chat open → no path change; matching id from list → re-attach push, no duplicate; different id → slot replaced, path set (not appended); approval badge bookkeeping preserved
+- [x] run tests — must pass before task 7
 
 ### Task 7: Verify acceptance criteria
 

--- a/docs/plans/completed/20260716-keep-running-session-alive.md
+++ b/docs/plans/completed/20260716-keep-running-session-alive.md
@@ -275,10 +275,10 @@ struct BackgroundTaskClient {
 
 ### Task 8: Update documentation and close out
 
-- [ ] update `CLAUDE.md` conventions: the live-chat-slot ownership rule, BackgroundTaskClient, push-tap dedup routing
-- [ ] update `README.md` if the feature list mentions lifecycle behavior
-- [ ] post the #33 write-up comment (decision: 30s grace + slot; no background modes) and reference this plan; note #32 is fixed
-- [ ] move this plan to `docs/plans/completed/`
+- [x] update `CLAUDE.md` conventions: the live-chat-slot ownership rule, BackgroundTaskClient, push-tap dedup routing
+- [x] update `README.md` if the feature list mentions lifecycle behavior — no change needed: the "Stays connected" bullet already describes restore-on-reopen accurately; the new behavior only strengthens it (nothing is now wrong)
+- [x] post the #33 write-up comment (decision: 30s grace + slot; no background modes) and reference this plan; note #32 is fixed (drafted; posted with PR)
+- [x] move this plan to `docs/plans/completed/`
 
 ## Post-Completion
 

--- a/docs/plans/completed/20260716-keep-running-session-alive.md
+++ b/docs/plans/completed/20260716-keep-running-session-alive.md
@@ -220,7 +220,9 @@ struct BackgroundTaskClient {
 **Files:**
 - Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
 - Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
-- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/HydrateTests.swift` *(deviation: the plan
+  originally listed `ChatFeatureTests.swift`, which does not exist — the chat-side reattach
+  tests exercise the hydrate path and live in `HydrateTests.swift`)*
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 
 - [x] add `ChatFeature.Action.reattached`: socket alive (`status == .ready` with a live session) → re-run the hydrate effect directly (no reconnect); socket dead → behave like `.foreground` (reset `hasRequestedSession`, `connect`)
@@ -286,9 +288,55 @@ struct BackgroundTaskClient {
 - Device test: background mid-turn < 30s → return: streaming never dropped (watch for the reconnect status flash — there should be none).
 - Device test: background > 30s → push arrives on completion; foreground → hydrate with preserved thinking/tool rows.
 - Device test: pop to list mid-turn, watch the row glow, re-open → live re-attach.
+- Device test: push tap for session B while session A's chat is open → B connects and
+  streams (whether SwiftUI re-fires `ChatView.task` for the replaced marker is a
+  view-runtime question the reducer tests can't answer).
+- Device test: idle pop transition — the outgoing chat screen stays rendered through the
+  whole pop animation (teardown is deferred to the view's disappearance; a blank outgoing
+  screen would mean the slot was cleared too early).
 - Battery sanity: idle backgrounding starts no background task (Xcode Energy gauge).
 
 **External follow-ups:**
 - Close #32 and #33 on GitHub after merge (#33 gets the decision write-up comment).
 - Server-side replay buffer for reasoning/tool events missed while disconnected remains
   an upstream gap (related: #30 re-surfacing pending approvals) — out of scope here.
+
+**#33 write-up (drafted in `/tmp/issue-33-writeup.md`; posted with the PR):**
+
+> Spike resolved — decision write-up.
+>
+> **Options considered**
+>
+> - **`beginBackgroundTask` (~30s grace)** — keeps the socket alive briefly after
+>   backgrounding, then flush + clean disconnect. Cheap, App Store-safe, covers the common
+>   "switch apps for a moment" case.
+> - **Background modes (audio/VoIP/processing)** — rejected: none legitimately apply to a
+>   chat client; misusing them is an App Store rejection risk and a battery cost.
+> - **`BGTaskScheduler` reconnect** — rejected: opportunistic wakeups give no real-time
+>   guarantee and add nothing over the existing push-notification + hydrate catch-up path
+>   we already have.
+>
+> **Decision: client-only, no hermes-agent changes**
+>
+> 1. **Live-chat-slot architecture** — the open chat's state moved from the navigation
+>    stack into an `AppFeature`-owned slot (`liveChat: ChatFeature.State?`); the nav path
+>    holds only thin session-id markers. Popping to the session list no longer cancels the
+>    socket: a running turn keeps streaming, thinking/tool rows accumulate, and re-opening
+>    re-attaches live (hydrate always; redial only if the socket is actually dead).
+>    Teardown is an explicit `AppFeature` policy (idle pop, turn end while detached, slot
+>    replacement, archive, logout).
+> 2. **~30s background grace** — a new `BackgroundTaskClient`
+>    (`UIApplication.beginBackgroundTask`) keeps the socket alive after `.background`; on
+>    expiry: final persist + socket-only teardown (state stays in memory), then the
+>    existing push + foreground reconnect/hydrate catch-up (with the #26 live-row
+>    preservation) takes over. Idle backgrounding starts no task.
+> 3. As part of the same routing work, push-tap handling now dedups against the slot —
+>    fixes #32 (tapping a push for the already-open session stacked a duplicate chat
+>    screen).
+>
+> Shipped in [PR link] (plan: `docs/plans/completed/20260716-keep-running-session-alive.md`).
+> Known remaining gap (upstream, out of scope): reasoning/tool events streamed while fully
+> disconnected are unrecoverable client-side — the server keeps no replay buffer
+> (related: #30).
+>
+> Closes #33; #32 is fixed by the same PR.


### PR DESCRIPTION
Keeps a running session alive when the user leaves the chat screen — both when popping back to the sessions list and for a short grace window after backgrounding — so an in-flight turn's live streaming (thinking, tool calls, assistant text) is no longer lost.

Closes #33
Closes #32

## What changed

**Live-chat-slot architecture (nav-pop case).** The open chat's state moved out of the navigation stack into an `AppFeature`-owned slot (`liveChat: ChatFeature.State?`); the path now holds thin `ChatScreen` session-key markers. The socket, reconnect backoff, thinking ticker, and persist effects are slot-rooted, so popping to the list cancels nothing: a running turn keeps streaming into the slot (list row glow stays live), and re-opening re-attaches instantly — hydrate always, redial only if the socket is actually dead. Teardown is an explicit `AppFeature` policy: idle pop (deferred until after the pop animation), turn end while detached (including client-side failure paths), slot replacement (routed through a nil-out so *all* child effects cancel), archive of the slot's session, logout/identity switch.

**~30s background grace (backgrounding case).** New `BackgroundTaskClient` (`UIApplication.beginBackgroundTask` behind a `@DependencyClient`). On `.background` with a running turn: snapshot flush + begin the grace task — the socket simply keeps streaming. On expiry: final flush + socket-only teardown that preserves all in-memory state for the #26-preserving foreground re-hydrate; the existing push-notification + reconnect catch-up takes over. Foregrounding before expiry reuses the still-healthy socket without a redial. Idle backgrounding starts no task.

**Push-tap dedup (#32).** Tap routing compares the pushed `session_id` against the slot + path: already on that chat → no navigation (in-place update); on the list with that session detached → live re-attach, no duplicate; different session → slot replacement with the path SET (no stacking on cold launch).

**Hardening from the review passes.** Hydrate is cancellable (`CancelID.hydrate`) and cancelled on every deliberate teardown; hydrate timeout over a possibly-half-open socket retries once on the same socket before redialing (and never redials during the reauth pause); `.disconnected` hydrate failures stay backoff-governed; a stale grace expiry after reactivation is a no-op; the live background-task box is generation-scoped against stale expiration handlers; `canSend` gained the missing `!isSending` guard.

## Spike outcome (#33)

Options considered: `beginBackgroundTask` (~30s, chosen), background modes (rejected — none legitimately apply, App Store risk), `BGTaskScheduler` (rejected — adds nothing over the existing push + hydrate catch-up). Decision: client-only, no hermes-agent changes. Known remaining gap (upstream, out of scope): reasoning/tool events streamed while fully disconnected are unrecoverable client-side — the server keeps no replay buffer (related: #30).

Full design history: `docs/plans/completed/20260716-keep-running-session-alive.md`.

## Testing

- 702 tests / 49 suites passing (`swift test`), including new suites for slot lifecycle, re-attach guard, background grace, push-tap routing, socket-leak instrumentation, and timer continuity.
- Snapshot suite green (76/76, no visual changes); `tuist generate` + simulator build clean.
- Manual device checks listed in the plan's Post-Completion section (background <30s / >30s mid-turn, pop-and-return mid-turn, push tap for B while A open, idle-pop transition, battery gauge).
