### PR TITLE
Fix cold-launch push-tap replay so the chat opens (issue #46)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,20 +285,30 @@ build/test/distribution, and `docs/plans/completed/` for the full design history
   requested on the sessions-list appearance** (right after login), per the product decision — NOT
   first launch. **`PushClient` is iOS-only-guarded** like `AudioRecorderClient` (`#if
   canImport(UIKit)`; non-iOS `liveValue = testValue`); keep pure logic (hex, `apnsEnv`, payload
-  parse, foreground-suppression) outside the guard. **All four triggers fire via real plugin
-  hooks** (CLI + gateway): approval (`pre_approval_request`), turn-complete (`post_llm_call`,
-  gated to ~>10s turns via a `pre_llm_call` start anchor), error (`on_session_end`, genuine
-  failures only — not success/interrupt), and clarify (`pre_tool_call` filtered to the `clarify`
-  tool, fired before the user is prompted — not duration-gated). **Cold-launch taps replay**
+  parse, foreground-suppression) — and `PushBridge` itself (Foundation-only: `NSLock` +
+  `AsyncStream`) — outside the guard so the stream/buffer behavior is macOS-tested. **All four
+  triggers fire via real plugin hooks** (CLI + gateway): approval (`pre_approval_request`),
+  turn-complete (`post_llm_call`, gated to ~>10s turns via a `pre_llm_call` start anchor),
+  error (`on_session_end`, genuine failures only — not success/interrupt), and clarify
+  (`pre_tool_call` filtered to the `clarify` tool, fired before the user is prompted — not
+  duration-gated). **Cold-launch taps replay**
   (#46) — a launch-from-push tap is dropped at two independent points unless both are covered:
-  `PushBridge` buffers a tap that fires with no `tapStream()` subscriber and the first
+  `PushBridge` buffers a tap that fires with no **live** `tapStream()` subscriber and the first
   subscriber drains it **consume-once** (cleared after delivery — a stale tap must not
-  re-navigate a later re-subscriber, unlike the idempotent `lastToken` replay); and a tap
-  arriving before `state.home` exists is stashed in `AppFeature.State.pendingPushTap`
-  (process-lifetime, badge bookkeeping unchanged) and re-sent as `.pushTapped` when `home`
+  re-navigate a later re-subscriber, unlike the idempotent `lastToken` replay; terminated
+  continuations are pruned via `onTermination`, so a cancelled observer can't strand a dead
+  entry that defeats the `isEmpty` buffer gate); and a tap arriving before `state.home` exists
+  is stashed in `AppFeature.State.pendingPushTap` (single stash, last-wins; process-lifetime,
+  cleared on logout, badge bookkeeping unchanged) and re-sent as `.pushTapped` when `home`
   is created (`.autoConnectSucceeded` AND the manual-login `.onboarding(.delegate(.connected))`)
   — always replay through the one #32 routing path (slot dedup, approval-hint arming,
-  placeholder `Session(id:)` + `session.resume`), never call `openSession` directly.
+  placeholder `Session(id:)` + `session.resume`), never call `openSession` directly. The stash
+  records the persisted server URL at stash time and a login to a **different** server drops it
+  (scrubbing its badge entry) instead of replaying — resuming a foreign session id would trip
+  the resume self-heal into creating a spurious empty chat; an unknown origin (logged out, no
+  stored URL) replays unverified. Home creation seeds the persisted profile selection
+  (`makeHomeState`) so the replayed open resumes under the right profile — the replay fires
+  before the list's `.task` prefs reload.
 - **Multi-profile switching** is **device-local** with **per-call scoping** — the selected
   profile *name* persists in `PreferencesClient` (`hermes.selected-profile-id`, cleared on
   logout). We do **NOT** call `POST /api/profiles/active` (that mutates the server's sticky

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,7 +289,16 @@ build/test/distribution, and `docs/plans/completed/` for the full design history
   hooks** (CLI + gateway): approval (`pre_approval_request`), turn-complete (`post_llm_call`,
   gated to ~>10s turns via a `pre_llm_call` start anchor), error (`on_session_end`, genuine
   failures only — not success/interrupt), and clarify (`pre_tool_call` filtered to the `clarify`
-  tool, fired before the user is prompted — not duration-gated).
+  tool, fired before the user is prompted — not duration-gated). **Cold-launch taps replay**
+  (#46) — a launch-from-push tap is dropped at two independent points unless both are covered:
+  `PushBridge` buffers a tap that fires with no `tapStream()` subscriber and the first
+  subscriber drains it **consume-once** (cleared after delivery — a stale tap must not
+  re-navigate a later re-subscriber, unlike the idempotent `lastToken` replay); and a tap
+  arriving before `state.home` exists is stashed in `AppFeature.State.pendingPushTap`
+  (process-lifetime, badge bookkeeping unchanged) and re-sent as `.pushTapped` when `home`
+  is created (`.autoConnectSucceeded` AND the manual-login `.onboarding(.delegate(.connected))`)
+  — always replay through the one #32 routing path (slot dedup, approval-hint arming,
+  placeholder `Session(id:)` + `session.resume`), never call `openSession` directly.
 - **Multi-profile switching** is **device-local** with **per-call scoping** — the selected
   profile *name* persists in `PreferencesClient` (`hermes.selected-profile-id`, cleared on
   logout). We do **NOT** call `POST /api/profiles/active` (that mutates the server's sticky

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -1,4 +1,5 @@
 import ComposableArchitecture
+import Foundation
 
 /// Root feature: onboarding until connected, then a session list that pushes chat
 /// screens. Wires the child features together via their delegate actions.
@@ -34,9 +35,25 @@ public struct AppFeature {
     var isSceneBackgrounded = false
     /// A push tap that arrived before the session list existed (cold launch — #46): the
     /// routing in `.pushTapped` can't open anything without `home`, so the tap is stashed
-    /// here and replayed once `.autoConnectSucceeded` / a manual login creates the list.
-    /// Process-lifetime only (never persisted) — the race it covers is intra-launch.
+    /// here (single stash, last-wins) and replayed once `.autoConnectSucceeded` / a manual
+    /// login creates the list. Process-lifetime only (never persisted) — the race it
+    /// covers is intra-launch — and cleared on logout (the stash dies with the identity).
     var pendingPushTap: PushTap?
+    /// The server the stashed tap belongs to: the persisted server URL at stash time (the
+    /// agent whose push plugin this device registered with). Guards the replay — a login
+    /// that targets a DIFFERENT server drops the stash instead of resuming a foreign
+    /// session id there (the resume self-heal would silently create a spurious empty
+    /// chat). `nil` when no URL was stored at stash time (fully logged out); the replay
+    /// then proceeds unverified — the plan's logged-out → login → open flow, accepted
+    /// because pushes only come from a server this device registered with.
+    ///
+    /// This is the best identity available CLIENT-SIDE, not proof of origin: the push
+    /// payload carries no server identity (the generic-body privacy rule forbids adding
+    /// one), so a push from a STALE registration on a previous server — logout's
+    /// unregister is best-effort — is stamped with the CURRENT pref and replays here.
+    /// Accepted corner: the worst outcome is the same spurious-empty-chat the self-heal
+    /// produces for any unknown id, and logout's unregister keeps the window narrow.
+    var pendingPushTapServerURL: URL?
 
     public init(
       onboarding: ConnectionFeature.State = .init(),
@@ -181,7 +198,7 @@ public struct AppFeature {
 
       case let .autoConnectSucceeded(connection):
         state.autoConnecting = false
-        state.home = SessionListFeature.State(connection: connection)
+        state.home = makeHomeState(connection: connection)
         return replayPendingPushTap(&state)
 
       case let .autoConnectFailed(connection):
@@ -269,9 +286,12 @@ public struct AppFeature {
         }
         guard state.home != nil else {
           // No session list yet (cold launch still auto-connecting or on onboarding) — can't
-          // open. Stash the tap for replay once the list exists (#46); the badge reflects
-          // the now-pending approval either way.
+          // open. Stash the tap for replay once the list exists (#46), remembering which
+          // server it belongs to (the stored URL — the agent this device's push
+          // registration points at) so a login to a DIFFERENT server drops it instead of
+          // replaying; the badge reflects the now-pending approval either way.
           state.pendingPushTap = tap
+          state.pendingPushTapServerURL = preferences.loadServerURL().flatMap(parseServerURL)
           return setBadge(state)
         }
         // The tapped session is the one ALREADY on screen (slot match + marker on the
@@ -305,7 +325,7 @@ public struct AppFeature {
         return .send(.home(.delegate(.openSession(session))))
 
       case let .onboarding(.delegate(.connected(connection))):
-        state.home = SessionListFeature.State(connection: connection)
+        state.home = makeHomeState(connection: connection)
         // Auto-connect failure falls back to onboarding, so a manual login must also replay
         // a stashed cold-launch tap (#46).
         return replayPendingPushTap(&state)
@@ -423,13 +443,20 @@ public struct AppFeature {
 
       case .home(.delegate(.disconnect)):
         // Token cleared in Settings → tear down and return to onboarding. Nil-ing the slot
-        // auto-cancels its effects (socket included).
+        // auto-cancels its effects (socket included). The tap stash is structurally nil
+        // here (home existed, so any stash was consumed at creation) — cleared
+        // defensively: the stash dies with the identity. The pending-approval badge set
+        // dies with it too (entries reference sessions on the server just left — they'd
+        // leak a stale icon badge into the next login), so reset the badge to zero.
         let connection = state.home?.connection
         state.path = .init()
         state.liveChat = nil
         state.home = nil
         state.onboarding = .init()
-        return unregisterPushOnLogout(connection: connection)
+        state.pendingPushTap = nil
+        state.pendingPushTapServerURL = nil
+        state.pendingApprovalSessionIDs = []
+        return .merge(setBadge(state), unregisterPushOnLogout(connection: connection))
 
       case .liveChat(.delegate(.sessionExpired)):
         // The live (gated) session died — attached or detached, the slot is the one chat.
@@ -447,14 +474,22 @@ public struct AppFeature {
           return .send(.liveChat(.resumeAfterReauth(connection)))
         }
         // Different user signed in → drop everything identity-scoped and force a fresh list.
+        // (`makeHomeState` reads the profile pref AFTER the clear, so it seeds defaults.)
+        // The approval badge set + tap stash are identity-scoped too — the old user's
+        // pending approvals must not badge (or replay into) the new user's list.
         preferences.clearIdentityScopedPrefs()
         state.path = .init()
         state.liveChat = nil
-        state.home = SessionListFeature.State(connection: connection)
-        return .none
+        state.pendingPushTap = nil
+        state.pendingPushTapServerURL = nil
+        state.pendingApprovalSessionIDs = []
+        state.home = makeHomeState(connection: connection)
+        return setBadge(state)
 
       case .reauth(.presented(.delegate(.quit))):
         // "Quit to start" → full logout (Keychain session + every pref) → onboarding.
+        // The tap stash and the approval badge set die with the identity (same clears
+        // as `.disconnect`, through the other logout path); badge reset to zero.
         let connection = state.home?.connection ?? state.liveChat?.connection
         try? keychain.deleteSession()
         preferences.clearServerURL()
@@ -465,7 +500,10 @@ public struct AppFeature {
         state.liveChat = nil
         state.home = nil
         state.onboarding = .init()
-        return unregisterPushOnLogout(connection: connection)
+        state.pendingPushTap = nil
+        state.pendingPushTapServerURL = nil
+        state.pendingApprovalSessionIDs = []
+        return .merge(setBadge(state), unregisterPushOnLogout(connection: connection))
 
       case let .liveChat(.delegate(.runningChanged(sessionID, running))):
         // Route the live chat's authoritative working-state change to the session list so its
@@ -537,15 +575,69 @@ public struct AppFeature {
     )
   }
 
+  /// Build a fresh session-list state, seeding the device-local persisted profile
+  /// selection (normally reloaded later, in the list view's `.task`). Seeding at creation
+  /// matters for work that runs BEFORE the list appears — the cold-launch push-tap replay
+  /// (#46) opens a chat synchronously here, and an unseeded `scopedProfileName` would
+  /// resume the session UNSCOPED (wrong `state.db` on a non-default profile →
+  /// "session not found" → the self-heal recreates a spurious empty chat under
+  /// "default"). A persisted non-default name implies the agent supported profiles when
+  /// it was selected (prefs are wiped on logout, bounding staleness); the list's
+  /// capability probe still corrects `profilesSupported` right after. A profile
+  /// deleted/renamed server-side since selection is the accepted corner: the scoped
+  /// resume fails exactly as a warm list-tap under the same stale pref would — parity
+  /// with the warm path is the contract, and the rare stale-profile miss is a far
+  /// smaller surface than the unscoped-resume misroute this seeding fixes (which hit
+  /// EVERY cold-launch replay on a non-default profile).
+  private func makeHomeState(connection: ServerConnection) -> SessionListFeature.State {
+    let persisted = SessionListFeature.State.persistedProfileName(preferences)
+    return SessionListFeature.State(
+      connection: connection,
+      selectedProfileName: persisted,
+      profilesSupported: persisted != SessionListFeature.State.defaultProfileName
+    )
+  }
+
   /// Consume the cold-launch tap stash (#46): a tap dropped while `home` was nil is
   /// replayed through the normal `.pushTapped` routing the moment the list exists — slot
   /// compare, #32 dedup, and approval-hint arming all reuse the one code path (duplicating
   /// any of it here would drift). No stash → no effect. The replayed approval badge insert
   /// is idempotent (`Set` insert; the open then clears it, netting zero like a warm tap).
+  ///
+  /// Cross-server guard: a stash whose recorded origin differs from the server just
+  /// connected to is DROPPED, not replayed — resuming a foreign session id would trip the
+  /// "session not found" self-heal into creating a spurious empty chat. Dropping also
+  /// scrubs EVERY pending-approval badge entry, not just the stashed tap's: the stash is
+  /// last-wins, but every pre-home tap was stamped with the same origin (the persisted
+  /// URL is constant across the pre-home window, and each identity teardown clears the
+  /// set), so earlier badged approvals are equally foreign — they can never be viewed
+  /// here (a foreign session never appears in this server's list, and opening is the
+  /// only other clear path), and would otherwise stick for the process lifetime. An
+  /// unknown origin (`nil` — no stored URL at stash time) replays unverified; see
+  /// `pendingPushTapServerURL`.
   private func replayPendingPushTap(_ state: inout State) -> Effect<Action> {
     guard let tap = state.pendingPushTap else { return .none }
+    let origin = state.pendingPushTapServerURL
     state.pendingPushTap = nil
+    state.pendingPushTapServerURL = nil
+    if let origin, let connected = state.home?.connection.baseURL,
+       !Self.isSameServer(origin, connected) {
+      guard !state.pendingApprovalSessionIDs.isEmpty else { return .none }
+      state.pendingApprovalSessionIDs.removeAll()
+      return setBadge(state)
+    }
     return .send(.pushTapped(tap))
+  }
+
+  /// Server identity for the stash guard: scheme + host (both case-insensitive per
+  /// RFC 3986, so lowercased) + literal port — path/trailing-slash/casing variations of
+  /// the same server must not drop a legitimate replay. Default-port drift
+  /// (`http://host` vs `http://host:80`) is accepted as a mismatch: both URLs come from
+  /// the same persisted-string pipeline, so they only diverge across a genuine re-login.
+  private static func isSameServer(_ a: URL, _ b: URL) -> Bool {
+    a.scheme?.lowercased() == b.scheme?.lowercased()
+      && a.host?.lowercased() == b.host?.lowercased()
+      && a.port == b.port
   }
 
   /// Fill the live-chat slot and (re)set the navigation path to that chat's single marker.

--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -32,6 +32,11 @@ public struct AppFeature {
     /// `.active`). Guards `.backgroundGraceExpired`: an expiry whose send escaped just as
     /// the user returned must not tear down the socket `.active` freshly redialed.
     var isSceneBackgrounded = false
+    /// A push tap that arrived before the session list existed (cold launch — #46): the
+    /// routing in `.pushTapped` can't open anything without `home`, so the tap is stashed
+    /// here and replayed once `.autoConnectSucceeded` / a manual login creates the list.
+    /// Process-lifetime only (never persisted) — the race it covers is intra-launch.
+    var pendingPushTap: PushTap?
 
     public init(
       onboarding: ConnectionFeature.State = .init(),
@@ -177,7 +182,7 @@ public struct AppFeature {
       case let .autoConnectSucceeded(connection):
         state.autoConnecting = false
         state.home = SessionListFeature.State(connection: connection)
-        return .none
+        return replayPendingPushTap(&state)
 
       case let .autoConnectFailed(connection):
         // Stored creds didn't validate (expired token / dead cookies / server moved) — fall
@@ -263,8 +268,10 @@ public struct AppFeature {
           state.pendingApprovalSessionIDs.insert(tap.sessionID)
         }
         guard state.home != nil else {
-          // No session list yet (e.g. cold launch still on onboarding) — can't open; the badge
-          // reflects the now-pending approval.
+          // No session list yet (cold launch still auto-connecting or on onboarding) — can't
+          // open. Stash the tap for replay once the list exists (#46); the badge reflects
+          // the now-pending approval either way.
+          state.pendingPushTap = tap
           return setBadge(state)
         }
         // The tapped session is the one ALREADY on screen (slot match + marker on the
@@ -299,7 +306,9 @@ public struct AppFeature {
 
       case let .onboarding(.delegate(.connected(connection))):
         state.home = SessionListFeature.State(connection: connection)
-        return .none
+        // Auto-connect failure falls back to onboarding, so a manual login must also replay
+        // a stashed cold-launch tap (#46).
+        return replayPendingPushTap(&state)
 
       case let .home(.delegate(.openSession(session))):
         guard let home = state.home else { return .none }
@@ -526,6 +535,17 @@ public struct AppFeature {
       .run { [backgroundTask] _ in await backgroundTask.end() },
       .concatenate(chain)
     )
+  }
+
+  /// Consume the cold-launch tap stash (#46): a tap dropped while `home` was nil is
+  /// replayed through the normal `.pushTapped` routing the moment the list exists — slot
+  /// compare, #32 dedup, and approval-hint arming all reuse the one code path (duplicating
+  /// any of it here would drift). No stash → no effect. The replayed approval badge insert
+  /// is idempotent (`Set` insert; the open then clears it, netting zero like a warm tap).
+  private func replayPendingPushTap(_ state: inout State) -> Effect<Action> {
+    guard let tap = state.pendingPushTap else { return .none }
+    state.pendingPushTap = nil
+    return .send(.pushTapped(tap))
   }
 
   /// Fill the live-chat slot and (re)set the navigation path to that chat's single marker.

--- a/HermesKit/Sources/HermesKit/Clients/PushClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/PushClient.swift
@@ -228,6 +228,11 @@ public extension PushClient {
     /// Push a device token into the `register()` stream as if APNs delivered it.
     public func emit(token: String) { box.emit(token: token) }
     /// Push a tap into the `incomingTaps()` stream as if the user tapped a notification.
+    /// Taps are delivered LIVE-ONLY: unlike the production `PushBridge`, the double does
+    /// no launch-race buffering, so a tap emitted with no active subscriber is silently
+    /// dropped — deterministic for tests (subscribe first, then emit). To exercise the
+    /// cold-launch buffer itself, inject a real `PushBridge` behind a `PushClient`
+    /// instead (see `coldLaunchTapBufferedInBridgeReplaysThroughTaskObserver`).
     public func emit(tap: PushTap) { box.emit(tap: tap) }
     /// Change the granted result the next `requestAuthorization()` returns.
     public func setAuthorized(_ granted: Bool) { box.setAuthorized(granted) }
@@ -257,10 +262,17 @@ public final class PushBridge: @unchecked Sendable {
   public static let shared = PushBridge()
 
   private let lock = NSLock()
-  private var tokenContinuations: [AsyncStream<String>.Continuation] = []
-  private var tapContinuations: [AsyncStream<PushTap>.Continuation] = []
+  /// Live subscribers, keyed per-subscription so `onTermination` can prune the exact
+  /// continuation when its consumer goes away (the reducer's `.task` observer is
+  /// cancelled and re-subscribed — `cancelInFlight` — leaving a gap where a tap must
+  /// buffer, not vanish into a dead continuation). Pruning keeps the dictionaries from
+  /// accreting dead entries; on the tap side `tapReceived` additionally inspects each
+  /// yield's RESULT, so even a terminated-but-not-yet-pruned continuation (its
+  /// `onTermination` still racing for this lock) can't swallow a tap.
+  private var tokenContinuations: [UUID: AsyncStream<String>.Continuation] = [:]
+  private var tapContinuations: [UUID: AsyncStream<PushTap>.Continuation] = [:]
   private var lastToken: String?
-  /// The last tap that arrived with zero subscribers (a launch-from-push fires the app
+  /// The last tap no live subscriber accepted (a launch-from-push fires the app
   /// delegate's `didReceive` before the reducer's `.task` subscribes — #46). Unlike
   /// `lastToken` (idempotent, replayed to every late subscriber), a tap is consume-once:
   /// the first `tapStream()` subscriber drains it, so a stale tap never re-navigates a
@@ -295,46 +307,75 @@ public final class PushBridge: @unchecked Sendable {
 
   func tokenStream() -> AsyncStream<String> {
     AsyncStream { continuation in
-      let cached: String? = lock.withLock {
-        tokenContinuations.append(continuation)
-        return lastToken
+      let id = UUID()
+      lock.withLock {
+        tokenContinuations[id] = continuation
+        // Re-deliver the most recent token so a late subscriber still registers. Yielded
+        // inside the lock so a concurrent rotation can't slot a newer token in front.
+        if let cached = lastToken { continuation.yield(cached) }
       }
-      // Re-deliver the most recent token so a late subscriber still registers.
-      if let cached { continuation.yield(cached) }
+      // Prune on consumer termination (cancellation/dealloc) so dead continuations never
+      // accumulate. Registered after insertion — a stream that already terminated invokes
+      // the handler immediately, so the entry is removed either way.
+      continuation.onTermination = { [weak self] _ in
+        guard let self else { return }
+        self.lock.withLock { _ = self.tokenContinuations.removeValue(forKey: id) }
+      }
     }
   }
 
   func tapStream() -> AsyncStream<PushTap> {
     AsyncStream { continuation in
-      let buffered: PushTap? = lock.withLock {
-        tapContinuations.append(continuation)
-        defer { pendingTap = nil }
-        return pendingTap
+      let id = UUID()
+      lock.withLock {
+        tapContinuations[id] = continuation
+        // Deliver the tap that raced ahead of subscription (launch-from-push), exactly
+        // once. Yielded INSIDE the lock: a `tapReceived` on another thread must not slot
+        // a newer tap in front of the buffered one — for taps, delivery order is the
+        // contract (the consumer's last-wins routing navigates to the final tap).
+        if let buffered = pendingTap {
+          pendingTap = nil
+          continuation.yield(buffered)
+        }
       }
-      // Deliver the tap that raced ahead of subscription (launch-from-push), exactly once.
-      if let buffered { continuation.yield(buffered) }
+      // Prune on consumer termination so `tapContinuations.isEmpty` keeps meaning "no
+      // LIVE subscriber" — the buffer must re-engage after the observer goes away (the
+      // reducer's `.task` re-fire cancels the old effect before the replacement
+      // subscribes; a tap landing in that gap has to buffer, not no-op into a dead
+      // continuation).
+      continuation.onTermination = { [weak self] _ in
+        guard let self else { return }
+        self.lock.withLock { _ = self.tapContinuations.removeValue(forKey: id) }
+      }
     }
   }
 
   /// Called by the app delegate on `didRegisterForRemoteNotificationsWithDeviceToken`.
   public func tokenReceived(_ data: Data) {
     let hex = PushClient.hexToken(from: data)
-    let continuations: [AsyncStream<String>.Continuation] = lock.withLock {
+    lock.withLock {
       lastToken = hex
-      return tokenContinuations
+      for continuation in tokenContinuations.values { continuation.yield(hex) }
     }
-    for continuation in continuations { continuation.yield(hex) }
   }
 
-  /// Called by the app delegate on a notification tap (`didReceive`). With no subscriber
-  /// yet (cold launch), the tap is buffered for the first `tapStream()` subscriber.
+  /// Called by the app delegate on a notification tap (`didReceive`). When no live
+  /// subscriber ACCEPTS the tap, it is buffered for the next `tapStream()` subscriber.
+  /// Acceptance is judged per-yield, not by `tapContinuations.isEmpty`: a consumer
+  /// cancelled on another thread can leave its already-terminated continuation in the
+  /// dictionary while its `onTermination` prune waits for this lock — yielding to it
+  /// returns `.terminated` and delivers nothing, so the tap must fall back to the
+  /// buffer instead of vanishing. Yields happen inside the lock so two rapid taps
+  /// can't be observed out of order.
   public func tapReceived(_ payload: [AnyHashable: Any]) {
     guard let tap = PushClient.tap(fromPayload: payload) else { return }
-    let continuations: [AsyncStream<PushTap>.Continuation] = lock.withLock {
-      if tapContinuations.isEmpty { pendingTap = tap }
-      return tapContinuations
+    lock.withLock {
+      var delivered = false
+      for continuation in tapContinuations.values {
+        if case .enqueued = continuation.yield(tap) { delivered = true }
+      }
+      if !delivered { pendingTap = tap }
     }
-    for continuation in continuations { continuation.yield(tap) }
   }
 }
 

--- a/HermesKit/Sources/HermesKit/Clients/PushClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/PushClient.swift
@@ -260,6 +260,13 @@ public final class PushBridge: @unchecked Sendable {
   private var tokenContinuations: [AsyncStream<String>.Continuation] = []
   private var tapContinuations: [AsyncStream<PushTap>.Continuation] = []
   private var lastToken: String?
+  /// The last tap that arrived with zero subscribers (a launch-from-push fires the app
+  /// delegate's `didReceive` before the reducer's `.task` subscribes — #46). Unlike
+  /// `lastToken` (idempotent, replayed to every late subscriber), a tap is consume-once:
+  /// the first `tapStream()` subscriber drains it, so a stale tap never re-navigates a
+  /// later re-subscriber. A tap delivered to at least one live continuation is never
+  /// cached — buffering exists only for the launch race.
+  private var pendingTap: PushTap?
   /// The session the user is currently viewing, set by the reducer (via
   /// `PushClient.setCurrentSession`) on chat open/close. Read by `willPresent` to decide
   /// foreground suppression — kept here so the app delegate carries no state of its own.
@@ -299,7 +306,13 @@ public final class PushBridge: @unchecked Sendable {
 
   func tapStream() -> AsyncStream<PushTap> {
     AsyncStream { continuation in
-      lock.withLock { tapContinuations.append(continuation) }
+      let buffered: PushTap? = lock.withLock {
+        tapContinuations.append(continuation)
+        defer { pendingTap = nil }
+        return pendingTap
+      }
+      // Deliver the tap that raced ahead of subscription (launch-from-push), exactly once.
+      if let buffered { continuation.yield(buffered) }
     }
   }
 
@@ -313,10 +326,14 @@ public final class PushBridge: @unchecked Sendable {
     for continuation in continuations { continuation.yield(hex) }
   }
 
-  /// Called by the app delegate on a notification tap (`didReceive`).
+  /// Called by the app delegate on a notification tap (`didReceive`). With no subscriber
+  /// yet (cold launch), the tap is buffered for the first `tapStream()` subscriber.
   public func tapReceived(_ payload: [AnyHashable: Any]) {
     guard let tap = PushClient.tap(fromPayload: payload) else { return }
-    let continuations = lock.withLock { tapContinuations }
+    let continuations: [AsyncStream<PushTap>.Continuation] = lock.withLock {
+      if tapContinuations.isEmpty { pendingTap = tap }
+      return tapContinuations
+    }
     for continuation in continuations { continuation.yield(tap) }
   }
 }

--- a/HermesKit/Sources/HermesKit/Clients/PushClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/PushClient.swift
@@ -246,6 +246,81 @@ public extension PushClient {
   }
 }
 
+// MARK: - App-delegate bridge (process-wide hub)
+
+/// Process-wide hub the app-delegate bridge (C2) feeds tokens/taps into, fanned out to
+/// every `register()` / `incomingTaps()` consumer. Lives here so the bridge has no logic
+/// of its own — it just calls `tokenReceived` / `tapReceived`. Uses only Foundation
+/// (`NSLock`, `AsyncStream`) + the pure `PushClient` helpers, so it sits OUTSIDE the
+/// UIKit guard and its stream/buffering behavior is unit-tested on macOS (`swift test`).
+public final class PushBridge: @unchecked Sendable {
+  public static let shared = PushBridge()
+
+  private let lock = NSLock()
+  private var tokenContinuations: [AsyncStream<String>.Continuation] = []
+  private var tapContinuations: [AsyncStream<PushTap>.Continuation] = []
+  private var lastToken: String?
+  /// The session the user is currently viewing, set by the reducer (via
+  /// `PushClient.setCurrentSession`) on chat open/close. Read by `willPresent` to decide
+  /// foreground suppression — kept here so the app delegate carries no state of its own.
+  private var currentSessionID: String?
+
+  /// Internal (not `private`) so unit tests can create isolated instances; production
+  /// code goes through `shared`.
+  init() {}
+
+  /// Update the currently-viewing session (reducer → `PushClient.setCurrentSession`).
+  public func setCurrentSession(_ sessionID: String?) {
+    lock.withLock { currentSessionID = sessionID }
+  }
+
+  /// Decide whether a foreground push should present its banner, given the session it
+  /// targets. Suppresses (returns `false`) when the user is already viewing that session.
+  /// Called by the app delegate's `willPresent`; the actual rule is the pure
+  /// `PushClient.shouldPresentForeground`.
+  public func shouldPresentForeground(for payload: [AnyHashable: Any]) -> Bool {
+    let incoming = PushClient.sessionID(fromPayload: payload)
+    let viewing = lock.withLock { currentSessionID }
+    return PushClient.shouldPresentForeground(
+      incomingSessionID: incoming, currentlyViewingSessionID: viewing
+    )
+  }
+
+  func tokenStream() -> AsyncStream<String> {
+    AsyncStream { continuation in
+      let cached: String? = lock.withLock {
+        tokenContinuations.append(continuation)
+        return lastToken
+      }
+      // Re-deliver the most recent token so a late subscriber still registers.
+      if let cached { continuation.yield(cached) }
+    }
+  }
+
+  func tapStream() -> AsyncStream<PushTap> {
+    AsyncStream { continuation in
+      lock.withLock { tapContinuations.append(continuation) }
+    }
+  }
+
+  /// Called by the app delegate on `didRegisterForRemoteNotificationsWithDeviceToken`.
+  public func tokenReceived(_ data: Data) {
+    let hex = PushClient.hexToken(from: data)
+    let continuations: [AsyncStream<String>.Continuation] = lock.withLock {
+      lastToken = hex
+      return tokenContinuations
+    }
+    for continuation in continuations { continuation.yield(hex) }
+  }
+
+  /// Called by the app delegate on a notification tap (`didReceive`).
+  public func tapReceived(_ payload: [AnyHashable: Any]) {
+    guard let tap = PushClient.tap(fromPayload: payload) else { return }
+    let continuations = lock.withLock { tapContinuations }
+    for continuation in continuations { continuation.yield(tap) }
+  }
+}
+
 // MARK: - Live (iOS only)
 
 // `UNUserNotificationCenter`/`UIApplication.registerForRemoteNotifications` are iOS-only;
@@ -255,75 +330,6 @@ public extension PushClient {
 #if canImport(UIKit)
   import UIKit
   import UserNotifications
-
-  /// Process-wide hub the app-delegate bridge (C2) feeds tokens/taps into, fanned out to
-  /// every `register()` / `incomingTaps()` consumer. Lives here so the bridge has no logic
-  /// of its own — it just calls `tokenReceived` / `tapReceived`.
-  public final class PushBridge: @unchecked Sendable {
-    public static let shared = PushBridge()
-
-    private let lock = NSLock()
-    private var tokenContinuations: [AsyncStream<String>.Continuation] = []
-    private var tapContinuations: [AsyncStream<PushTap>.Continuation] = []
-    private var lastToken: String?
-    /// The session the user is currently viewing, set by the reducer (via
-    /// `PushClient.setCurrentSession`) on chat open/close. Read by `willPresent` to decide
-    /// foreground suppression — kept here so the app delegate carries no state of its own.
-    private var currentSessionID: String?
-
-    private init() {}
-
-    /// Update the currently-viewing session (reducer → `PushClient.setCurrentSession`).
-    public func setCurrentSession(_ sessionID: String?) {
-      lock.withLock { currentSessionID = sessionID }
-    }
-
-    /// Decide whether a foreground push should present its banner, given the session it
-    /// targets. Suppresses (returns `false`) when the user is already viewing that session.
-    /// Called by the app delegate's `willPresent`; the actual rule is the pure
-    /// `PushClient.shouldPresentForeground`.
-    public func shouldPresentForeground(for payload: [AnyHashable: Any]) -> Bool {
-      let incoming = PushClient.sessionID(fromPayload: payload)
-      let viewing = lock.withLock { currentSessionID }
-      return PushClient.shouldPresentForeground(
-        incomingSessionID: incoming, currentlyViewingSessionID: viewing
-      )
-    }
-
-    func tokenStream() -> AsyncStream<String> {
-      AsyncStream { continuation in
-        let cached: String? = lock.withLock {
-          tokenContinuations.append(continuation)
-          return lastToken
-        }
-        // Re-deliver the most recent token so a late subscriber still registers.
-        if let cached { continuation.yield(cached) }
-      }
-    }
-
-    func tapStream() -> AsyncStream<PushTap> {
-      AsyncStream { continuation in
-        lock.withLock { tapContinuations.append(continuation) }
-      }
-    }
-
-    /// Called by the app delegate on `didRegisterForRemoteNotificationsWithDeviceToken`.
-    public func tokenReceived(_ data: Data) {
-      let hex = PushClient.hexToken(from: data)
-      let continuations: [AsyncStream<String>.Continuation] = lock.withLock {
-        lastToken = hex
-        return tokenContinuations
-      }
-      for continuation in continuations { continuation.yield(hex) }
-    }
-
-    /// Called by the app delegate on a notification tap (`didReceive`).
-    public func tapReceived(_ payload: [AnyHashable: Any]) {
-      guard let tap = PushClient.tap(fromPayload: payload) else { return }
-      let continuations = lock.withLock { tapContinuations }
-      for continuation in continuations { continuation.yield(tap) }
-    }
-  }
 
   extension PushClient {
     public static var liveValue: PushClient {

--- a/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
@@ -101,6 +101,14 @@ public struct SessionListFeature {
     /// The default profile name — never renamable/deletable, and the implicit fallback.
     public static let defaultProfileName = "default"
 
+    /// The device-local persisted profile selection, falling back to
+    /// `defaultProfileName`. The ONE fallback rule, shared by the list's `.task` prefs
+    /// reload and `AppFeature.makeHomeState`'s creation-time seeding (#46) — change it
+    /// here and both sites follow.
+    static func persistedProfileName(_ preferences: PreferencesClient) -> String {
+      preferences.loadSelectedProfileID() ?? defaultProfileName
+    }
+
     /// Collapsed groups show at most this many rows before a "Show more".
     public static let collapsedLimit = 5
 
@@ -462,8 +470,7 @@ public struct SessionListFeature {
         // Refresh "now", reload persisted prefs (incl. the device-local selected profile),
         // probe the profiles capability, and start the auto-poll loop.
         reloadPrefs(&state)
-        state.selectedProfileName =
-          preferences.loadSelectedProfileID() ?? Self.State.defaultProfileName
+        state.selectedProfileName = Self.State.persistedProfileName(preferences)
         state.isLoading = true
         return .merge(
           .run { [profiles, connection = state.connection] send in

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -1739,28 +1739,24 @@ struct AppFeatureTests {
     await store.send(.liveChat(.teardown))
   }
 
-  /// An approval tap with no session list yet (can't open) bumps the pending-approval badge;
-  /// then opening that session clears it back to zero.
-  @Test func approvalBadgeSetsWhenUnopenedAndClearsOnView() async {
+  /// A pending approval badge whose tap couldn't open its session (and wasn't the one the
+  /// cold-launch replay opened — e.g. the older of two pre-home taps, #46 last-wins) clears
+  /// when the session is opened later from the LIST, and the entry read before the clear
+  /// threads the recovery hint into the freshly-filled slot (#30 badged-then-opened-later).
+  @Test func approvalBadgeClearsAndThreadsHintWhenOpenedFromList() async {
     let push = PushClient.inMemory()
-    // Onboarding (no home) — the tap can't open a session, so the badge reflects the pending approval.
-    let store = TestStore(initialState: AppFeature.State()) {
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(connection: connection),
+        pendingApprovalSessionIDs: ["s-approve"]
+      )
+    ) {
       AppFeature()
     } withDependencies: {
       $0.push = push.client
     }
     store.exhaustivity = .off
 
-    await store.send(.pushTapped(PushTap(sessionID: "s-approve", type: "approval"))) {
-      $0.pendingApprovalSessionIDs = ["s-approve"]
-    }
-    await store.finish()
-    #expect(push.badgeCount == 1) // badge shows the pending approval
-
-    // Now sign in and open that session → badge clears.
-    await store.send(.autoConnectSucceeded(connection)) {
-      $0.home = SessionListFeature.State(connection: self.connection)
-    }
     await store.send(.home(.delegate(.openSession(Session(id: "s-approve"))))) {
       $0.pendingApprovalSessionIDs = []
     }
@@ -2106,7 +2102,9 @@ struct AppFeatureTests {
     #expect(store.state.liveChat?.expectsPendingApproval == false)
   }
 
-  /// Two distinct pending approvals → badge count 2; opening one → badge drops to 1.
+  /// Two distinct pending approvals → badge count 2. Only the LAST pre-home tap is stashed
+  /// for the cold-launch replay (#46, last-wins): sign-in auto-opens "s-two" (badge → 1);
+  /// the still-badged "s-one" then clears when opened from the list (badge → 0).
   @Test func multiplePendingApprovalsSetBadgeThenClearOne() async {
     let push = PushClient.inMemory()
     // Onboarding (no home) so the approval taps can't open and just accumulate as pending.
@@ -2114,26 +2112,162 @@ struct AppFeatureTests {
       AppFeature()
     } withDependencies: {
       $0.push = push.client
+      $0.chatSnapshot = .inMemory()
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
     }
     store.exhaustivity = .off
 
     await store.send(.pushTapped(PushTap(sessionID: "s-one", type: "approval"))) {
       $0.pendingApprovalSessionIDs = ["s-one"]
+      $0.pendingPushTap = PushTap(sessionID: "s-one", type: "approval")
     }
     await store.send(.pushTapped(PushTap(sessionID: "s-two", type: "approval"))) {
       $0.pendingApprovalSessionIDs = ["s-one", "s-two"]
+      // Last-wins: a newer pre-home tap replaces the stash — only one tap replays.
+      $0.pendingPushTap = PushTap(sessionID: "s-two", type: "approval")
     }
     await store.finish()
     #expect(push.badgeCount == 2) // two pending approvals
 
-    // Sign in and open one of them → badge drops to the remaining pending count.
+    // Sign in → the stashed LAST tap replays and opens s-two; its entry clears.
     await store.send(.autoConnectSucceeded(connection)) {
       $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
     }
-    await store.send(.home(.delegate(.openSession(Session(id: "s-one"))))) {
-      $0.pendingApprovalSessionIDs = ["s-two"]
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession) {
+      $0.pendingApprovalSessionIDs = ["s-one"]
     }
     await store.finish()
     #expect(push.badgeCount == 1)
+    #expect(store.state.liveChat?.storedSessionID == "s-two")
+
+    // Open the remaining badged session from the list → badge drops to zero (the occupied
+    // slot is replaced through the standard teardown-then-fill).
+    await store.send(.home(.delegate(.openSession(Session(id: "s-one"))))) {
+      $0.pendingApprovalSessionIDs = []
+    }
+    await store.skipReceivedActions()
+    await store.finish()
+    #expect(push.badgeCount == 0)
+    #expect(store.state.liveChat?.storedSessionID == "s-one")
+  }
+
+  // MARK: Cold-launch push-tap replay (#46)
+
+  /// Cold launch: the tap arrives while auto-connect is still probing (`home == nil`) — it
+  /// must be STASHED, then replayed through the one `.pushTapped` routing path the moment
+  /// `.autoConnectSucceeded` creates the list, opening the never-seen session via the
+  /// placeholder `Session(id:)` fallback.
+  @Test func coldLaunchTapStashedThenReplayedOnAutoConnect() async {
+    let store = TestStore(initialState: AppFeature.State(autoConnecting: true)) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    // Pre-home tap: stash only — nothing to navigate yet.
+    await store.send(.pushTapped(PushTap(sessionID: "20260724_cron"))) {
+      $0.pendingPushTap = PushTap(sessionID: "20260724_cron")
+    }
+    #expect(store.state.liveChat == nil)
+    #expect(store.state.path.isEmpty)
+
+    // The list arriving consumes the stash and replays the tap through normal routing.
+    await store.send(.autoConnectSucceeded(connection)) {
+      $0.autoConnecting = false
+      $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
+    }
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession)
+    // The placeholder `Session(id:)` fallback resumed the never-seen session.
+    #expect(store.state.liveChat?.storedSessionID == "20260724_cron")
+    #expect(store.state.path.last?.sessionKey == "20260724_cron")
+  }
+
+  /// Auto-connect FAILED → the user lands on onboarding; the stashed tap must survive to a
+  /// manual login (`.onboarding(.delegate(.connected))`) and replay then.
+  @Test func coldLaunchTapReplayedAfterManualLogin() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "s-manual"))) {
+      $0.pendingPushTap = PushTap(sessionID: "s-manual")
+    }
+    await store.send(.onboarding(.delegate(.connected(connection)))) {
+      $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
+    }
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession)
+    #expect(store.state.liveChat?.storedSessionID == "s-manual")
+    #expect(store.state.path.last?.sessionKey == "s-manual")
+  }
+
+  /// An approval tap dropped pre-home badges the session (it can't open yet); the replay
+  /// then opens it through the normal flow — arming the recovery hint (#30) — and the
+  /// open's mark-then-clear badge bookkeeping nets the entry back to zero.
+  @Test func coldLaunchApprovalTapReplaysArmingHintAndNetsBadgeZero() async {
+    let push = PushClient.inMemory()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.push = push.client
+    }
+    store.exhaustivity = .off
+
+    // Dropped approval tap: badged + stashed.
+    await store.send(.pushTapped(PushTap(sessionID: "s-approve", type: "approval"))) {
+      $0.pendingApprovalSessionIDs = ["s-approve"]
+      $0.pendingPushTap = PushTap(sessionID: "s-approve", type: "approval")
+    }
+    await store.finish()
+    #expect(push.badgeCount == 1)
+
+    // The replay re-runs the (idempotent) badge insert, then the open clears it — net zero.
+    await store.send(.autoConnectSucceeded(connection)) {
+      $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
+    }
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession) {
+      $0.pendingApprovalSessionIDs = []
+    }
+    await store.finish()
+    #expect(push.badgeCount == 0)
+    // The badge entry read before the clear armed the recovery hint on the fresh slot (#30).
+    #expect(store.state.liveChat?.expectsPendingApproval == true)
+    #expect(store.state.liveChat?.storedSessionID == "s-approve")
+  }
+
+  /// Existing-behavior guard: a warm tap (list present) routes immediately and never
+  /// touches the stash.
+  @Test func warmTapNeverTouchesPendingStash() async {
+    let store = TestStore(
+      initialState: AppFeature.State(home: SessionListFeature.State(connection: connection))
+    ) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "s-warm")))
+    await store.receive(\.home.delegate.openSession)
+    #expect(store.state.pendingPushTap == nil)
+    #expect(store.state.liveChat?.storedSessionID == "s-warm")
+  }
+
+  /// Existing-behavior guard: `.autoConnectSucceeded` with no stash emits no replay
+  /// (exhaustive — a stray `.pushTapped` follow-up would fail this send).
+  @Test func autoConnectWithoutStashEmitsNoReplay() async {
+    let store = TestStore(initialState: AppFeature.State(autoConnecting: true)) {
+      AppFeature()
+    }
+
+    await store.send(.autoConnectSucceeded(connection)) {
+      $0.autoConnecting = false
+      $0.home = SessionListFeature.State(connection: self.connection)
+    }
   }
 }

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -98,6 +98,10 @@ struct AppFeatureTests {
     await store.send(.task)
   }
 
+  /// Exhaustive — this doubles as the no-replay guard for the manual-login path (#46):
+  /// `.onboarding(.delegate(.connected))` with no stashed tap must emit no stray
+  /// `.pushTapped` (an unexpected follow-up action would fail the send), mirroring
+  /// `autoConnectWithoutStashEmitsNoReplay`.
   @Test func connectingShowsSessionList() async {
     let store = TestStore(initialState: AppFeature.State()) { AppFeature() }
 
@@ -912,6 +916,7 @@ struct AppFeatureTests {
 
   @Test func differentUserReauthPopsToListAndClearsIdentityPrefs() async {
     let fresh = freshCookieConnection(username: "bob")
+    let push = PushClient.inMemory()
     let pinsCleared = LockIsolated(false)
     let seenCleared = LockIsolated(false)
     let profileCleared = LockIsolated(false)
@@ -923,7 +928,9 @@ struct AppFeatureTests {
         reauth: ReauthFeature.State(
           serverURL: URL(string: "http://mac.tailnet:9119")!, method: .password,
           provider: "basic", previousUsername: "alice"
-        )
+        ),
+        // The old user's pending approval must not badge the new user's list.
+        pendingApprovalSessionIDs: ["s-alice"]
       )
     ) {
       AppFeature()
@@ -931,18 +938,23 @@ struct AppFeatureTests {
       $0.preferences.savePinnedIDs = { @Sendable ids in if ids.isEmpty { pinsCleared.setValue(true) } }
       $0.preferences.saveSeenCounts = { @Sendable c in if c.isEmpty { seenCleared.setValue(true) } }
       $0.preferences.clearSelectedProfileID = { @Sendable in profileCleared.setValue(true) }
+      $0.push = push.client
     }
     store.exhaustivity = .off
+    await push.client.setBadgeCount(1)
 
     await store.send(.reauth(.presented(.delegate(.reauthenticated(connection: fresh, sameUser: false))))) {
       $0.reauth = nil
       $0.path = .init()
       $0.liveChat = nil
+      $0.pendingApprovalSessionIDs = []
       $0.home = SessionListFeature.State(connection: fresh)
     }
     #expect(pinsCleared.value)
     #expect(seenCleared.value)
     #expect(profileCleared.value)
+    await store.finish()
+    #expect(push.badgeCount == 0)
   }
 
   @Test func quitFromReauthFullyLogsOutToOnboarding() async {
@@ -2160,8 +2172,11 @@ struct AppFeatureTests {
   /// `.autoConnectSucceeded` creates the list, opening the never-seen session via the
   /// placeholder `Session(id:)` fallback.
   @Test func coldLaunchTapStashedThenReplayedOnAutoConnect() async {
+    let push = PushClient.inMemory()
     let store = TestStore(initialState: AppFeature.State(autoConnecting: true)) {
       AppFeature()
+    } withDependencies: {
+      $0.push = push.client
     }
     store.exhaustivity = .off
 
@@ -2180,9 +2195,14 @@ struct AppFeatureTests {
     }
     await store.receive(\.pushTapped)
     await store.receive(\.home.delegate.openSession)
+    await store.finish()
     // The placeholder `Session(id:)` fallback resumed the never-seen session.
     #expect(store.state.liveChat?.storedSessionID == "20260724_cron")
     #expect(store.state.path.last?.sessionKey == "20260724_cron")
+    // A NON-approval tap must never touch the approval badge — neither on the stash
+    // branch nor on the replay.
+    #expect(store.state.pendingApprovalSessionIDs.isEmpty)
+    #expect(push.badgeCount == 0)
   }
 
   /// Auto-connect FAILED → the user lands on onboarding; the stashed tap must survive to a
@@ -2204,6 +2224,8 @@ struct AppFeatureTests {
     await store.receive(\.home.delegate.openSession)
     #expect(store.state.liveChat?.storedSessionID == "s-manual")
     #expect(store.state.path.last?.sessionKey == "s-manual")
+    // Non-approval tap → the approval badge set stays untouched end to end.
+    #expect(store.state.pendingApprovalSessionIDs.isEmpty)
   }
 
   /// An approval tap dropped pre-home badges the session (it can't open yet); the replay
@@ -2269,5 +2291,216 @@ struct AppFeatureTests {
       $0.autoConnecting = false
       $0.home = SessionListFeature.State(connection: self.connection)
     }
+  }
+
+  /// A cold-launch replay must open the session under the PERSISTED profile: the replay
+  /// fires synchronously at home creation, BEFORE the list's `.task` reloads prefs — an
+  /// unseeded profile would resume unscoped (wrong `state.db` on a non-default profile),
+  /// and the "session not found" self-heal would recreate the session empty under
+  /// "default".
+  @Test func coldLaunchReplayResumesUnderPersistedProfile() async {
+    let store = TestStore(initialState: AppFeature.State(autoConnecting: true)) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences.loadSelectedProfileID = { "work" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "cron_job1_20260724"))) {
+      $0.pendingPushTap = PushTap(sessionID: "cron_job1_20260724")
+    }
+    // Home is seeded with the persisted selection (the list's capability probe still
+    // corrects `profilesSupported` afterwards).
+    await store.send(.autoConnectSucceeded(connection)) {
+      $0.autoConnecting = false
+      $0.home = SessionListFeature.State(
+        connection: self.connection, selectedProfileName: "work", profilesSupported: true
+      )
+      $0.pendingPushTap = nil
+    }
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession)
+    // The replayed open threads the persisted profile into the chat, so `session.resume`
+    // scopes to the right `state.db`.
+    #expect(store.state.liveChat?.profileName == "work")
+    #expect(store.state.liveChat?.storedSessionID == "cron_job1_20260724")
+  }
+
+  /// End-to-end #46 launch race: the app delegate's `didReceive` fires BEFORE the
+  /// reducer's `.task` subscribes (true launch-from-push). The real bridge buffers the
+  /// tap, the `.task` observer drains it into `.pushTapped`, the pre-home stash holds it,
+  /// and the login replays it into the open — both halves of the fix composed.
+  @Test func coldLaunchTapBufferedInBridgeReplaysThroughTaskObserver() async {
+    let bridge = PushBridge()
+    bridge.tapReceived(["session_id": "s-race"]) // before ANY subscriber exists
+
+    var client = PushClient.testValue
+    client.incomingTaps = { bridge.tapStream() }
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      // No stored creds → `.task` only starts the tap observer (no auto-connect).
+      $0.keychain.loadSession = { @Sendable _ in nil }
+      $0.preferences.loadServerURL = { nil }
+      $0.push = client
+    }
+    store.exhaustivity = .off
+
+    await store.send(.task)
+    // The buffered tap drains into the observer and stashes (no home yet).
+    await store.receive(\.pushTapped) {
+      $0.pendingPushTap = PushTap(sessionID: "s-race")
+    }
+    // Manual login → the stash replays into the open.
+    await store.send(.onboarding(.delegate(.connected(connection))))
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession)
+    #expect(store.state.liveChat?.storedSessionID == "s-race")
+    #expect(store.state.path.last?.sessionKey == "s-race")
+    // The tap observer is a long-running effect on the bridge stream — drop it at teardown.
+    await store.skipInFlightEffects()
+  }
+
+  /// A stash recorded under one server must NOT replay into a login that targets a
+  /// DIFFERENT server — resuming a foreign session id there would trip the resume
+  /// self-heal into creating a spurious empty chat. The stash is dropped and its
+  /// pending-approval badge entry scrubbed. Exhaustive: a stray `.pushTapped` replay
+  /// would fail the send.
+  @Test func stashedTapDroppedWhenLoginTargetsDifferentServer() async {
+    let push = PushClient.inMemory()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      // The URL stored when the tap arrived — the server the push came from.
+      $0.preferences.loadServerURL = { "http://old.tailnet:9119" }
+      $0.push = push.client
+    }
+
+    await store.send(.pushTapped(PushTap(sessionID: "s-old", type: "approval"))) {
+      $0.pendingApprovalSessionIDs = ["s-old"]
+      $0.pendingPushTap = PushTap(sessionID: "s-old", type: "approval")
+      $0.pendingPushTapServerURL = URL(string: "http://old.tailnet:9119")!
+    }
+    // Log into a DIFFERENT server → no replay; the foreign approval badge is scrubbed.
+    await store.send(.onboarding(.delegate(.connected(connection)))) {
+      $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
+      $0.pendingPushTapServerURL = nil
+      $0.pendingApprovalSessionIDs = []
+    }
+    await store.finish()
+    #expect(push.badgeCount == 0)
+  }
+
+  /// A cross-server drop scrubs EVERY pre-home approval badge entry, not just the
+  /// stashed (last-wins) tap's: an approval tap lands first, then a non-approval tap
+  /// overwrites the stash, and the login targets a DIFFERENT server. The earlier
+  /// approval's badge would otherwise leak for the process lifetime — a foreign session
+  /// never appears in the new server's list, so opening (the only other clear path)
+  /// can never happen. Exhaustive: a stray `.pushTapped` replay would fail the send.
+  @Test func crossServerDropScrubsAllPreHomeApprovalBadges() async {
+    let push = PushClient.inMemory()
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences.loadServerURL = { "http://old.tailnet:9119" }
+      $0.push = push.client
+    }
+
+    await store.send(.pushTapped(PushTap(sessionID: "s-approval", type: "approval"))) {
+      $0.pendingApprovalSessionIDs = ["s-approval"]
+      $0.pendingPushTap = PushTap(sessionID: "s-approval", type: "approval")
+      $0.pendingPushTapServerURL = URL(string: "http://old.tailnet:9119")!
+    }
+    // A later non-approval tap takes over the stash (last-wins); the approval stays badged.
+    await store.send(.pushTapped(PushTap(sessionID: "s-later"))) {
+      $0.pendingPushTap = PushTap(sessionID: "s-later")
+    }
+    // Log into a DIFFERENT server → no replay; the WHOLE foreign badge set is scrubbed.
+    await store.send(.onboarding(.delegate(.connected(connection)))) {
+      $0.home = SessionListFeature.State(connection: self.connection)
+      $0.pendingPushTap = nil
+      $0.pendingPushTapServerURL = nil
+      $0.pendingApprovalSessionIDs = []
+    }
+    await store.finish()
+    #expect(push.badgeCount == 0)
+  }
+
+  /// The plan's expired-creds flow: auto-connect fails (URL still stored), the user logs
+  /// back into the SAME server — a recorded origin matching the connection replays
+  /// normally. The stored URL deliberately differs in scheme/host CASING from the
+  /// connection's (`HTTP://Mac.…` vs `http://mac.…`): the compare is case-insensitive
+  /// per RFC 3986, so formatting drift can't drop a legitimate tap.
+  @Test func stashedTapReplaysWhenLoginTargetsSameServer() async {
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences.loadServerURL = { "HTTP://Mac.tailnet:9119" }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "s-same"))) {
+      $0.pendingPushTap = PushTap(sessionID: "s-same")
+      $0.pendingPushTapServerURL = URL(string: "HTTP://Mac.tailnet:9119")!
+    }
+    await store.send(.onboarding(.delegate(.connected(connection))))
+    await store.receive(\.pushTapped)
+    await store.receive(\.home.delegate.openSession)
+    #expect(store.state.liveChat?.storedSessionID == "s-same")
+  }
+
+  /// The stash AND the approval badge set die with the identity: Settings disconnect
+  /// clears both and resets the icon badge to zero, so no stale tap or prior-server
+  /// badge can survive into the next login. (Structurally the stash is already nil
+  /// whenever `home` exists — both creation sites consume it — so this pins the
+  /// defensive invariant.)
+  @Test func disconnectClearsPushTapStashAndApprovalBadges() async {
+    let push = PushClient.inMemory()
+    var initial = AppFeature.State(home: SessionListFeature.State(connection: connection))
+    initial.pendingPushTap = PushTap(sessionID: "s-stale")
+    initial.pendingPushTapServerURL = URL(string: "http://old.tailnet:9119")
+    initial.pendingApprovalSessionIDs = ["s-stale", "s-other"]
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.push = push.client
+    }
+    store.exhaustivity = .off
+    // Simulate the badge those entries had raised, so the reset to zero is observable.
+    await push.client.setBadgeCount(2)
+    await store.send(.home(.delegate(.disconnect)))
+    #expect(store.state.pendingPushTap == nil)
+    #expect(store.state.pendingPushTapServerURL == nil)
+    #expect(store.state.pendingApprovalSessionIDs.isEmpty)
+    await store.finish()
+    #expect(push.badgeCount == 0)
+  }
+
+  /// Reauth "Quit to start" (full logout) clears the stash and the approval badge set
+  /// too — the same defensive invariant as the Settings disconnect, through the other
+  /// logout path.
+  @Test func reauthQuitClearsPushTapStashAndApprovalBadges() async {
+    let push = PushClient.inMemory()
+    var initial = AppFeature.State(
+      home: SessionListFeature.State(connection: connection),
+      reauth: ReauthFeature.State(
+        serverURL: URL(string: "http://mac.tailnet:9119")!, method: .token
+      )
+    )
+    initial.pendingPushTap = PushTap(sessionID: "s-stale")
+    initial.pendingApprovalSessionIDs = ["s-stale"]
+    let store = TestStore(initialState: initial) {
+      AppFeature()
+    } withDependencies: {
+      $0.push = push.client
+    }
+    store.exhaustivity = .off
+    await push.client.setBadgeCount(1)
+    await store.send(.reauth(.presented(.delegate(.quit))))
+    #expect(store.state.pendingPushTap == nil)
+    #expect(store.state.pendingApprovalSessionIDs.isEmpty)
+    await store.finish()
+    #expect(push.badgeCount == 0)
   }
 }

--- a/HermesKit/Tests/HermesKitTests/PushClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/PushClientTests.swift
@@ -150,17 +150,44 @@ struct PushClientTests {
 
   // MARK: PushBridge token stream (outside the UIKit guard → testable on macOS)
 
+  /// Collect up to `count` values from `stream`, bailing out after `timeout` with an
+  /// EMPTY array (partial values are discarded — the tests only ever compare complete
+  /// arrays). A regression (a value never delivered) then FAILS the array comparison
+  /// instead of hanging the whole suite on an `iterator.next()` that never resolves.
+  private func collect<Value: Sendable>(
+    _ count: Int,
+    from stream: AsyncStream<Value>,
+    timeout: Duration = .seconds(2)
+  ) async -> [Value] {
+    await withTaskGroup(of: [Value]?.self) { group in
+      group.addTask {
+        var values: [Value] = []
+        for await value in stream {
+          values.append(value)
+          if values.count == count { break }
+        }
+        return values
+      }
+      group.addTask {
+        try? await Task.sleep(for: timeout)
+        return nil
+      }
+      // First finisher wins: the collector (complete) or the timeout (partial → `[]`).
+      let winner = await group.next() ?? nil
+      group.cancelAll()
+      return winner ?? []
+    }
+  }
+
   @Test func bridgeTokenStreamReplaysLastTokenToLateSubscriber() async {
     let bridge = PushBridge()
     // Token arrives BEFORE anyone subscribes (the launch race)…
     bridge.tokenReceived(Data([0xde, 0xad, 0xbe, 0xef]))
-    // …then the late subscriber still gets the cached token.
+    // …the late subscriber still gets the cached token first, then live rotations. The
+    // rotation doubles as a sentinel: a broken replay yields ["0ff0"], not a hang.
     let stream = bridge.tokenStream()
-    var iterator = stream.makeAsyncIterator()
-    #expect(await iterator.next() == "deadbeef")
-    // And a live subscriber keeps receiving subsequent tokens.
     bridge.tokenReceived(Data([0x0f, 0xf0]))
-    #expect(await iterator.next() == "0ff0")
+    #expect(await collect(2, from: stream) == ["deadbeef", "0ff0"])
   }
 
   // MARK: PushBridge tap buffering (cold-launch race, #46)
@@ -169,10 +196,15 @@ struct PushClientTests {
     let bridge = PushBridge()
     // Tap arrives BEFORE anyone subscribes (launch-from-push race)…
     bridge.tapReceived(["session_id": "s1", "type": "approval"])
-    // …then the first subscriber still receives the buffered tap.
+    // …then the first subscriber receives the buffered tap FIRST, ahead of any live
+    // follow-up (order is the contract — the consumer's last-wins routing must end on
+    // the newest tap). The follow-up doubles as the no-hang sentinel.
     let stream = bridge.tapStream()
-    var iterator = stream.makeAsyncIterator()
-    #expect(await iterator.next() == PushTap(sessionID: "s1", type: "approval"))
+    bridge.tapReceived(["session_id": "sentinel"])
+    #expect(await collect(2, from: stream) == [
+      PushTap(sessionID: "s1", type: "approval"),
+      PushTap(sessionID: "sentinel"),
+    ])
   }
 
   @Test func bridgeTapBufferIsConsumeOnce() async {
@@ -180,40 +212,71 @@ struct PushClientTests {
     bridge.tapReceived(["session_id": "s1"])
     // The first subscriber drains the buffer…
     let firstStream = bridge.tapStream()
-    var first = firstStream.makeAsyncIterator()
-    #expect(await first.next() == PushTap(sessionID: "s1"))
     // …so a later second subscriber must NOT see the stale tap again (re-yielding it
     // would re-navigate). Its first value is the next live tap, used as a sentinel.
     let secondStream = bridge.tapStream()
-    var second = secondStream.makeAsyncIterator()
     bridge.tapReceived(["session_id": "s2"])
-    #expect(await second.next() == PushTap(sessionID: "s2"))
+    #expect(await collect(2, from: firstStream) == [
+      PushTap(sessionID: "s1"), PushTap(sessionID: "s2"),
+    ])
+    #expect(await collect(1, from: secondStream) == [PushTap(sessionID: "s2")])
+  }
+
+  @Test func bridgeTapBufferKeepsOnlyTheNewestTap() async {
+    let bridge = PushBridge()
+    // Two taps land before anyone subscribes → the buffer is last-wins (a single stale
+    // navigation replay; the older tap must never arrive).
+    bridge.tapReceived(["session_id": "s1"])
+    bridge.tapReceived(["session_id": "s2"])
+    let stream = bridge.tapStream()
+    bridge.tapReceived(["session_id": "sentinel"])
+    // The sentinel occupying slot 2 proves "s1" was dropped, not merely delayed.
+    #expect(await collect(2, from: stream) == [
+      PushTap(sessionID: "s2"), PushTap(sessionID: "sentinel"),
+    ])
   }
 
   @Test func bridgeTapDeliveredLiveIsNotBuffered() async {
     let bridge = PushBridge()
     // A live subscriber receives the tap directly…
     let liveStream = bridge.tapStream()
-    var live = liveStream.makeAsyncIterator()
     bridge.tapReceived(["session_id": "s1"])
-    #expect(await live.next() == PushTap(sessionID: "s1"))
     // …and because it was delivered, it is NOT cached: a new subscriber gets nothing
     // buffered — its first value is the next live tap (sentinel), never the old one.
     let lateStream = bridge.tapStream()
-    var late = lateStream.makeAsyncIterator()
     bridge.tapReceived(["session_id": "s2"])
-    #expect(await late.next() == PushTap(sessionID: "s2"))
+    #expect(await collect(2, from: liveStream) == [
+      PushTap(sessionID: "s1"), PushTap(sessionID: "s2"),
+    ])
+    #expect(await collect(1, from: lateStream) == [PushTap(sessionID: "s2")])
   }
 
   @Test func bridgeTapReachesAllLiveSubscribers() async {
     let bridge = PushBridge()
     let streamA = bridge.tapStream()
     let streamB = bridge.tapStream()
-    var a = streamA.makeAsyncIterator()
-    var b = streamB.makeAsyncIterator()
     bridge.tapReceived(["session_id": "s1", "type": "complete"])
     let expected = PushTap(sessionID: "s1", type: "complete")
-    #expect(await a.next() == expected)
-    #expect(await b.next() == expected)
+    #expect(await collect(1, from: streamA) == [expected])
+    #expect(await collect(1, from: streamB) == [expected])
+  }
+
+  /// A subscriber that has TERMINATED (the reducer's `.task` observer being cancelled and
+  /// restarted) must not defeat the buffer: without `onTermination` pruning, its dead
+  /// continuation would keep `tapContinuations` non-empty forever, so a tap landing in
+  /// the re-subscribe gap would be yielded into the void instead of buffered (#46's drop,
+  /// resurrected in a narrower window).
+  @Test func bridgeTapBufferReengagesAfterSubscriberTermination() async {
+    let bridge = PushBridge()
+    // A subscriber comes and goes. Dropping the stream deallocates its storage, which
+    // fires the continuation's termination synchronously → the bridge prunes it.
+    var stream: AsyncStream<PushTap>? = bridge.tapStream()
+    _ = stream
+    stream = nil
+    // No LIVE subscriber remains → this tap must be buffered, not fanned out to the
+    // dead continuation.
+    bridge.tapReceived(["session_id": "s1"])
+    let revived = bridge.tapStream()
+    #expect(await collect(1, from: revived) == [PushTap(sessionID: "s1")])
   }
 }

--- a/HermesKit/Tests/HermesKitTests/PushClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/PushClientTests.swift
@@ -162,4 +162,58 @@ struct PushClientTests {
     bridge.tokenReceived(Data([0x0f, 0xf0]))
     #expect(await iterator.next() == "0ff0")
   }
+
+  // MARK: PushBridge tap buffering (cold-launch race, #46)
+
+  @Test func bridgeTapStreamDeliversBufferedTapToFirstSubscriber() async {
+    let bridge = PushBridge()
+    // Tap arrives BEFORE anyone subscribes (launch-from-push race)…
+    bridge.tapReceived(["session_id": "s1", "type": "approval"])
+    // …then the first subscriber still receives the buffered tap.
+    let stream = bridge.tapStream()
+    var iterator = stream.makeAsyncIterator()
+    #expect(await iterator.next() == PushTap(sessionID: "s1", type: "approval"))
+  }
+
+  @Test func bridgeTapBufferIsConsumeOnce() async {
+    let bridge = PushBridge()
+    bridge.tapReceived(["session_id": "s1"])
+    // The first subscriber drains the buffer…
+    let firstStream = bridge.tapStream()
+    var first = firstStream.makeAsyncIterator()
+    #expect(await first.next() == PushTap(sessionID: "s1"))
+    // …so a later second subscriber must NOT see the stale tap again (re-yielding it
+    // would re-navigate). Its first value is the next live tap, used as a sentinel.
+    let secondStream = bridge.tapStream()
+    var second = secondStream.makeAsyncIterator()
+    bridge.tapReceived(["session_id": "s2"])
+    #expect(await second.next() == PushTap(sessionID: "s2"))
+  }
+
+  @Test func bridgeTapDeliveredLiveIsNotBuffered() async {
+    let bridge = PushBridge()
+    // A live subscriber receives the tap directly…
+    let liveStream = bridge.tapStream()
+    var live = liveStream.makeAsyncIterator()
+    bridge.tapReceived(["session_id": "s1"])
+    #expect(await live.next() == PushTap(sessionID: "s1"))
+    // …and because it was delivered, it is NOT cached: a new subscriber gets nothing
+    // buffered — its first value is the next live tap (sentinel), never the old one.
+    let lateStream = bridge.tapStream()
+    var late = lateStream.makeAsyncIterator()
+    bridge.tapReceived(["session_id": "s2"])
+    #expect(await late.next() == PushTap(sessionID: "s2"))
+  }
+
+  @Test func bridgeTapReachesAllLiveSubscribers() async {
+    let bridge = PushBridge()
+    let streamA = bridge.tapStream()
+    let streamB = bridge.tapStream()
+    var a = streamA.makeAsyncIterator()
+    var b = streamB.makeAsyncIterator()
+    bridge.tapReceived(["session_id": "s1", "type": "complete"])
+    let expected = PushTap(sessionID: "s1", type: "complete")
+    #expect(await a.next() == expected)
+    #expect(await b.next() == expected)
+  }
 }

--- a/HermesKit/Tests/HermesKitTests/PushClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/PushClientTests.swift
@@ -147,4 +147,19 @@ struct PushClientTests {
     push.client.setCurrentSession(nil)
     #expect(push.currentSession == nil)
   }
+
+  // MARK: PushBridge token stream (outside the UIKit guard → testable on macOS)
+
+  @Test func bridgeTokenStreamReplaysLastTokenToLateSubscriber() async {
+    let bridge = PushBridge()
+    // Token arrives BEFORE anyone subscribes (the launch race)…
+    bridge.tokenReceived(Data([0xde, 0xad, 0xbe, 0xef]))
+    // …then the late subscriber still gets the cached token.
+    let stream = bridge.tokenStream()
+    var iterator = stream.makeAsyncIterator()
+    #expect(await iterator.next() == "deadbeef")
+    // And a live subscriber keeps receiving subsequent tokens.
+    bridge.tokenReceived(Data([0x0f, 0xf0]))
+    #expect(await iterator.next() == "0ff0")
+  }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,12 +88,16 @@ a `testValue`/`.inMemory()` variant):
 - **`PushClient`** — push notifications: `requestAuthorization`/`authorizationStatus`,
   device-token registration as an `AsyncStream<String>` (lowercase-hex, re-emits on OS token
   rotation), an `incomingTaps()` stream of `PushTap` values (carrying `session_id` + optional
-  `type`), and badge control (`setBadgeCount`). The `liveValue` is iOS-only-guarded
+  `type`; a tap that fires before any subscriber — launch-from-push, #46 — is buffered in
+  `PushBridge`, last-wins, and drained consume-once by the first subscriber), and badge
+  control (`setBadgeCount`). The `liveValue` is iOS-only-guarded
   (`#if canImport(UIKit)` over `UNUserNotificationCenter` + `registerForRemoteNotifications`,
-  fed by a process-wide `PushBridge` from the app-delegate adapter); the non-iOS fallback is
+  fed by the process-wide `PushBridge` from the app-delegate adapter); the non-iOS fallback is
   `testValue`, plus an `.inMemory()` variant. Pure helpers (hex encoding, the compile-time
-  `apnsEnv`, payload parsing, foreground-suppression decision) live outside the guard so they
-  are unit-tested on macOS.
+  `apnsEnv`, payload parsing, foreground-suppression decision) **and `PushBridge` itself**
+  (Foundation-only: `NSLock` + `AsyncStream`, with `onTermination`-pruned subscriber lists so
+  a cancelled observer can't strand a dead continuation and defeat the tap buffer) live
+  outside the guard so they are unit-tested on macOS.
 - **`BackgroundTaskClient`** — a finite background-execution window (~30s) wrapping
   `UIApplication.beginBackgroundTask`/`endBackgroundTask`: `begin(name) → AsyncStream<Void>`
   yields exactly once if iOS expires the window early (then finishes; a normal end finishes

--- a/docs/plans/20260724-cold-launch-push-tap-replay.md
+++ b/docs/plans/20260724-cold-launch-push-tap-replay.md
@@ -130,16 +130,16 @@
 - Modify: `HermesKit/Tests/HermesKitTests/PushClientTests.swift`
 - Modify: `HermesKit/Sources/HermesKit/Clients/PushClient.swift`
 
-- [ ] write failing test: `tapReceived` before any subscriber → first `tapStream()`
+- [x] write failing test: `tapReceived` before any subscriber → first `tapStream()`
       subscriber receives the buffered tap
-- [ ] write failing test: buffered tap is consume-once — a second, later `tapStream()`
+- [x] write failing test: buffered tap is consume-once — a second, later `tapStream()`
       subscriber does NOT receive it again
-- [ ] write failing test: a tap delivered to a live subscriber is not buffered — a
+- [x] write failing test: a tap delivered to a live subscriber is not buffered — a
       subsequent new subscriber receives nothing
-- [ ] write test (existing behavior guard): tap with live subscribers reaches all of them
-- [ ] implement `pendingTap` cache in `tapReceived` + drain in `tapStream()` per
+- [x] write test (existing behavior guard): tap with live subscribers reaches all of them
+- [x] implement `pendingTap` cache in `tapReceived` + drain in `tapStream()` per
       Technical Details
-- [ ] run tests — must pass before task 3
+- [x] run tests — must pass before task 3
 
 ### Task 3: Stash and replay the pre-home tap in AppFeature (TDD)
 

--- a/docs/plans/20260724-cold-launch-push-tap-replay.md
+++ b/docs/plans/20260724-cold-launch-push-tap-replay.md
@@ -1,0 +1,194 @@
+# Cold-launch push-tap replay (issue #46)
+
+## Overview
+- Tapping a push for a session the phone hasn't seen (new cron run, desktop-started chat)
+  when the tap **launches the app** lands on the sessions list — the chat never opens.
+- The "unknown session" case already works warm (placeholder `Session(id:)` +
+  `session.resume`); the bug is that on cold launch the tap is **dropped before routing**
+  in two independent places and never replayed:
+  1. `AppFeature.pushTapped` bails badge-only when `state.home == nil`
+     (`AppFeature.swift:265-269`); `.autoConnectSucceeded` sets `home` later but doesn't
+     re-process the dropped tap.
+  2. `PushBridge.tapStream()` doesn't buffer for late subscribers
+     (`PushClient.swift:304-308`) — on a true launch-from-push the app delegate's
+     `tapReceived` can fire before the reducer's `.task` subscribes, so with zero
+     continuations the tap is silently discarded. `tokenStream()` already caches
+     `lastToken` for exactly this reason.
+- Fix both holes: buffer the last undelivered tap in `PushBridge` (consume-once), and
+  stash a pre-`home` tap in `AppFeature.State` for replay once `home` exists.
+- No REST single-session fetch needed — the existing placeholder + `session.resume` path
+  hydrates title/history once the tap reaches `openSession`.
+- Closes goncharik/hermes-mobile#46.
+
+## Context (from discovery)
+- Files/components involved:
+  - `HermesKit/Sources/HermesKit/Clients/PushClient.swift` — `PushBridge`
+    (`tapStream`/`tapReceived`, lines 304-325) currently inside `#if canImport(UIKit)`.
+  - `HermesKit/Sources/HermesKit/AppFeature.swift` — `.pushTapped` guard (265-269),
+    `.autoConnectSucceeded` (177-180), `.onboarding(.delegate(.connected))` (300-302),
+    tap observer in `.task` (145-150).
+  - `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift` — existing `pushTapped`
+    TestStore coverage to extend.
+  - `HermesKit/Tests/HermesKitTests/PushClientTests.swift` — existing pure push tests.
+- Related patterns found:
+  - `tokenStream()` late-subscriber replay (`PushClient.swift:293-302`) is the exact
+    mirror for the tap-side fix — but a tap must be **consume-once** (re-yielding a stale
+    tap to a later re-subscriber would re-navigate), unlike the token which is idempotent.
+  - Pure payload helpers (`hexToken`, `tap(fromPayload:)`, `sessionID(fromPayload:)`,
+    `shouldPresentForeground`) already live OUTSIDE the UIKit guard — `PushBridge` itself
+    uses only Foundation (`NSLock`, `AsyncStream`) + those helpers, so it can move outside
+    the guard too, making the new buffering logic unit-testable on macOS (`swift test`).
+- Dependencies identified: none new — TCA `TestStore`, existing `PushClient` test doubles.
+
+## Development Approach
+- **Testing approach**: TDD (tests first) — per task, write the failing test, then the
+  implementation, then verify green.
+- Complete each task fully before moving to the next.
+- Make small, focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - tests are not optional — they are a required part of the checklist
+  - tests cover both success and error scenarios
+- **CRITICAL: all tests must pass before starting next task** — no exceptions.
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Run tests after each change (`script -q /dev/null swift test --package-path HermesKit`).
+- Maintain backward compatibility (badge bookkeeping for undeliverable taps unchanged).
+
+## Testing Strategy
+- **Unit tests**: required for every task. `PushBridge` buffering → direct unit tests
+  (possible once it's outside the UIKit guard); reducer replay → `TestStore`
+  event-reduction tests in `AppFeatureTests.swift`.
+- **Snapshot tests**: not applicable — no view changes.
+- **e2e**: none in this project; manual cold-launch verification listed under
+  Post-Completion.
+
+## Progress Tracking
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+- update plan if implementation deviates from original scope
+
+## Solution Overview
+- **`PushBridge` tap buffering (consume-once)**: `tapReceived` with zero subscribed
+  continuations caches the tap in `pendingTap`; the first `tapStream()` subscriber
+  drains it (yield + clear under the lock — mirror `tokenStream()`'s shape but clear
+  after delivery). A tap delivered to at least one live continuation is NOT cached —
+  buffering exists only for the launch race, not for replay to re-subscribers.
+- **Reducer stash-and-replay**: `pushTapped` with `state.home == nil` keeps today's badge
+  bookkeeping but also stores the tap in `state.pendingPushTap`. Both places that create
+  `home` — `.autoConnectSucceeded` and `.onboarding(.delegate(.connected))` (auto-connect
+  failure falls back to onboarding, so a manual login must also replay) — consume the
+  stash by re-sending `.pushTapped(tap)` through the normal routing (slot compare, #32
+  dedup, approval hint arming all reuse the one code path). Replaying re-runs the
+  `isApproval` badge insert — idempotent (`Set` insert + the open clears it, netting zero
+  exactly as a warm tap does).
+- **Why replay via `.pushTapped` and not `.openSession` directly**: the full routing case
+  already handles approval-hint arming, slot/path dedup, and the placeholder-session
+  fallback; duplicating any of it would drift.
+
+## Technical Details
+- `PushBridge` (moved outside `#if canImport(UIKit)`, stays in `PushClient.swift`):
+  - `private var pendingTap: PushTap?`
+  - `tapReceived`: `lock.withLock` — if `tapContinuations.isEmpty`, set `pendingTap`;
+    else yield to all continuations (and leave `pendingTap` nil).
+  - `tapStream()`: under the lock, append the continuation and take-and-clear
+    `pendingTap`; yield the drained tap after releasing the lock (same shape as
+    `tokenStream()`).
+  - The UIKit-only `liveValue` extension keeps referencing `PushBridge.shared` unchanged.
+- `AppFeature.State`: `var pendingPushTap: PushTap?` (not persisted — process-lifetime
+  only, the race it covers is intra-launch).
+- `AppFeature` reducer:
+  - `.pushTapped` `home == nil` branch: `state.pendingPushTap = tap` before the existing
+    `setBadge(state)` return.
+  - `.autoConnectSucceeded` / `.onboarding(.delegate(.connected))`: after setting
+    `state.home`, if `let tap = state.pendingPushTap` → clear it and
+    `return .send(.pushTapped(tap))` (merged with any existing effect).
+- `PushTap` already `Equatable`/`Sendable` as used by the stream — no model changes.
+
+## What Goes Where
+- **Implementation Steps** (`[ ]` checkboxes): code + tests in this repo.
+- **Post-Completion** (no checkboxes): manual on-device cold-launch verification.
+
+## Implementation Steps
+
+### Task 1: Move PushBridge outside the UIKit guard
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Clients/PushClient.swift`
+
+- [ ] move the `PushBridge` class above the `#if canImport(UIKit)` block; keep the
+      `liveValue` extension and app-delegate-facing UIKit code inside the guard
+- [ ] verify `PushBridge` compiles on macOS: only Foundation + pure `PushClient` helpers
+      (`hexToken`, `tap(fromPayload:)`, `sessionID(fromPayload:)`,
+      `shouldPresentForeground`) — no UIKit/UserNotifications symbols
+- [ ] write a smoke unit test in `PushClientTests.swift`: `tokenStream()` late-subscriber
+      replay via `PushBridge` (locks in existing behavior now that it's testable)
+- [ ] run tests — must pass before task 2
+
+### Task 2: Buffer the last undelivered tap in PushBridge (TDD)
+
+**Files:**
+- Modify: `HermesKit/Tests/HermesKitTests/PushClientTests.swift`
+- Modify: `HermesKit/Sources/HermesKit/Clients/PushClient.swift`
+
+- [ ] write failing test: `tapReceived` before any subscriber → first `tapStream()`
+      subscriber receives the buffered tap
+- [ ] write failing test: buffered tap is consume-once — a second, later `tapStream()`
+      subscriber does NOT receive it again
+- [ ] write failing test: a tap delivered to a live subscriber is not buffered — a
+      subsequent new subscriber receives nothing
+- [ ] write test (existing behavior guard): tap with live subscribers reaches all of them
+- [ ] implement `pendingTap` cache in `tapReceived` + drain in `tapStream()` per
+      Technical Details
+- [ ] run tests — must pass before task 3
+
+### Task 3: Stash and replay the pre-home tap in AppFeature (TDD)
+
+**Files:**
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+- Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
+
+- [ ] write failing TestStore test: cold-launch order — `.pushTapped(tap)` with
+      `home == nil` stashes the tap (badge bookkeeping unchanged), then
+      `.autoConnectSucceeded` clears the stash and replays into
+      `.home(.delegate(.openSession))` with the placeholder `Session(id:)`
+- [ ] write failing TestStore test: same replay through
+      `.onboarding(.delegate(.connected))` (auto-connect-failed → manual login path)
+- [ ] write failing TestStore test: approval tap pre-home — badge set on the drop,
+      replay arms `expectsPendingApproval` through the normal open flow and nets the
+      badge entry to zero
+- [ ] write test (existing behavior guard): warm-path `.pushTapped` with `home` present
+      never touches `pendingPushTap`; `.autoConnectSucceeded` without a stash emits no
+      replay
+- [ ] add `pendingPushTap` to `AppFeature.State`; stash in the `home == nil` branch;
+      consume + re-send `.pushTapped` from `.autoConnectSucceeded` and
+      `.onboarding(.delegate(.connected))`
+- [ ] run tests — must pass before task 4
+
+### Task 4: Verify acceptance criteria
+
+- [ ] verify both drop sites from issue #46 are closed (bridge buffer + reducer replay)
+- [ ] verify edge cases: tap for the session already in the slot after replay (slot-match
+      short-circuit still applies — replay goes through the same `.pushTapped` case);
+      non-approval tap replay; approval badge netting
+- [ ] run full test suite: `script -q /dev/null swift test --package-path HermesKit`
+- [ ] confirm no view changes → snapshot suite untouched, no re-record needed
+
+### Task 5: [Final] Update documentation
+
+- [ ] update `CLAUDE.md` push-notifications bullet: note the cold-launch tap replay
+      (bridge consume-once buffer + `pendingPushTap` reducer stash)
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+*Items requiring manual intervention or external systems — no checkboxes, informational only*
+
+**Manual verification:**
+- On-device: force-quit the app, trigger a push for a session the phone has never loaded
+  (e.g. a cron run), tap the notification → app cold-launches directly into that chat
+  with hydrated history.
+- Same flow while logged out / expired creds: tap should land on onboarding, and
+  completing login should then open the pushed session.
+
+**External system updates:**
+- None — no push-payload changes (generic-body privacy rule untouched), no plugin or
+  gateway changes.

--- a/docs/plans/20260724-cold-launch-push-tap-replay.md
+++ b/docs/plans/20260724-cold-launch-push-tap-replay.md
@@ -147,22 +147,28 @@
 - Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
 - Modify: `HermesKit/Sources/HermesKit/AppFeature.swift`
 
-- [ ] write failing TestStore test: cold-launch order — `.pushTapped(tap)` with
+- [x] write failing TestStore test: cold-launch order — `.pushTapped(tap)` with
       `home == nil` stashes the tap (badge bookkeeping unchanged), then
       `.autoConnectSucceeded` clears the stash and replays into
       `.home(.delegate(.openSession))` with the placeholder `Session(id:)`
-- [ ] write failing TestStore test: same replay through
+- [x] write failing TestStore test: same replay through
       `.onboarding(.delegate(.connected))` (auto-connect-failed → manual login path)
-- [ ] write failing TestStore test: approval tap pre-home — badge set on the drop,
+- [x] write failing TestStore test: approval tap pre-home — badge set on the drop,
       replay arms `expectsPendingApproval` through the normal open flow and nets the
       badge entry to zero
-- [ ] write test (existing behavior guard): warm-path `.pushTapped` with `home` present
+- [x] write test (existing behavior guard): warm-path `.pushTapped` with `home` present
       never touches `pendingPushTap`; `.autoConnectSucceeded` without a stash emits no
       replay
-- [ ] add `pendingPushTap` to `AppFeature.State`; stash in the `home == nil` branch;
+- [x] add `pendingPushTap` to `AppFeature.State`; stash in the `home == nil` branch;
       consume + re-send `.pushTapped` from `.autoConnectSucceeded` and
       `.onboarding(.delegate(.connected))`
-- [ ] run tests — must pass before task 4
+- [x] run tests — must pass before task 4
+- ➕ reworked two existing tests that pinned the old "dropped tap stays badged until
+  manually opened" behavior: `approvalBadgeSetsWhenUnopenedAndClearsOnView` →
+  `approvalBadgeClearsAndThreadsHintWhenOpenedFromList` (the #30 badged-then-opened-later
+  route, now seeded via initial state since a replay auto-opens the stashed tap);
+  `multiplePendingApprovalsSetBadgeThenClearOne` now covers last-wins stashing (only the
+  newest pre-home tap replays; the older one stays badged until opened from the list)
 
 ### Task 4: Verify acceptance criteria
 

--- a/docs/plans/20260724-cold-launch-push-tap-replay.md
+++ b/docs/plans/20260724-cold-launch-push-tap-replay.md
@@ -115,14 +115,14 @@
 **Files:**
 - Modify: `HermesKit/Sources/HermesKit/Clients/PushClient.swift`
 
-- [ ] move the `PushBridge` class above the `#if canImport(UIKit)` block; keep the
+- [x] move the `PushBridge` class above the `#if canImport(UIKit)` block; keep the
       `liveValue` extension and app-delegate-facing UIKit code inside the guard
-- [ ] verify `PushBridge` compiles on macOS: only Foundation + pure `PushClient` helpers
+- [x] verify `PushBridge` compiles on macOS: only Foundation + pure `PushClient` helpers
       (`hexToken`, `tap(fromPayload:)`, `sessionID(fromPayload:)`,
       `shouldPresentForeground`) — no UIKit/UserNotifications symbols
-- [ ] write a smoke unit test in `PushClientTests.swift`: `tokenStream()` late-subscriber
+- [x] write a smoke unit test in `PushClientTests.swift`: `tokenStream()` late-subscriber
       replay via `PushBridge` (locks in existing behavior now that it's testable)
-- [ ] run tests — must pass before task 2
+- [x] run tests — must pass before task 2
 
 ### Task 2: Buffer the last undelivered tap in PushBridge (TDD)
 

--- a/docs/plans/20260724-copy-session-id-menu.md
+++ b/docs/plans/20260724-copy-session-id-menu.md
@@ -1,0 +1,168 @@
+# Copy Session ID menu item
+
+## Overview
+- Add a "Copy ID" menu item that puts the session's id on the pasteboard, on three
+  surfaces: the sessions-list row context menu, the Archived-sessions sheet row context
+  menu, and the chat screen's toolbar ellipsis menu.
+- Solves: no way today to grab a session id from the app (useful for debugging,
+  cross-referencing with the agent's CLI/logs, cron job ids, etc.).
+- On copy, a small transient toast ("Session ID copied") confirms the action, then
+  auto-dismisses.
+
+## Context (from discovery)
+- Files/components involved:
+  - `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift` (+ tests)
+  - `HermesKit/Sources/HermesKit/Features/ArchivedSessionsFeature.swift` (+ tests)
+  - `HermesKit/Sources/HermesKit/Features/ChatFeature.swift` (+ tests)
+  - `HermesMobile/Sources/Features/SessionListView.swift` (row `.contextMenu`, line ~488)
+  - `HermesMobile/Sources/Features/ArchivedSessionsView.swift` (row `.contextMenu`, line ~30)
+  - `HermesMobile/Sources/Features/Chat/ChatView.swift` (toolbar `Menu`, line ~46)
+- Related patterns found:
+  - `PasteboardClient` already exists (`@DependencyClient`-style struct, live + test
+    values) and is already used by `ChatFeature` (`copyRow`/`copyCode` at
+    `ChatFeature.swift:908`) — copy goes view → action → reducer → `pasteboard.copy`.
+  - Timed feedback pattern exists: `copyCode` starts a cancellable `continuousClock`
+    sleep (`CancelID.copyFeedback`, `cancelInFlight: true`) that sends an expiry action.
+  - No existing toast/snackbar component — a small shared view is needed.
+- Dependencies identified: `PasteboardClient`, `continuousClock` (TestClock-drivable),
+  TCA `TestStore`.
+- ID semantics: list/archived rows copy `session.id`; chat copies
+  `state.sessionKey` (`storedSessionID ?? liveSessionID`, `ChatFeature.swift:126`) —
+  menu item disabled while `sessionKey == nil` (mirrors `canRename` gating).
+
+## Development Approach
+- **testing approach**: Regular (code first, then tests)
+- complete each task fully before moving to the next
+- make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  - tests are not optional - they are a required part of the checklist
+  - TestStore tests for every new action; success + no-op/edge cases
+- **CRITICAL: all tests must pass before starting next task** - no exceptions
+- **CRITICAL: update this plan file when scope changes during implementation**
+- run tests after each change
+- maintain backward compatibility
+
+## Testing Strategy
+- **unit tests** (HermesKit, `swift test` via
+  `script -q /dev/null swift test --package-path HermesKit` or `make test`):
+  - per feature: copy action puts the right id on the pasteboard (override
+    `\.pasteboard` with a `LockIsolated` capture), shows the toast, and a `TestClock`
+    advance auto-dismisses it; re-copy while visible restarts the timer
+    (`cancelInFlight`); chat copy with `sessionKey == nil` is a no-op.
+- **snapshot tests** (`make snapshot` / `make snapshot-record` in `HermesMobileTests`):
+  - one snapshot of the sessions list with the copied toast visible (covers the new
+    `CopiedToastView` rendering).
+- no e2e suite in this project.
+
+## Progress Tracking
+- mark completed items with `[x]` immediately when done
+- add newly discovered tasks with ➕ prefix
+- document issues/blockers with ⚠️ prefix
+- update plan if implementation deviates from original scope
+- keep plan in sync with actual work done
+
+## Solution Overview
+- Follow the established client pattern: views stay thin, each feature reducer gets a
+  copy action that calls `pasteboard.copy(...)` and flips a `showsCopiedIDToast: Bool`,
+  plus a timed expiry effect (cancellable `continuousClock.sleep(for: .seconds(1.5))`
+  → expiry action, `cancelInFlight: true` so rapid re-copies restart the timer).
+- One small shared SwiftUI view in the app target, `CopiedToastView` (capsule,
+  "Session ID copied", material background, bottom-aligned overlay with a fade/move
+  transition that respects reduce-motion), driven purely by the store bool on each of
+  the three screens.
+- Toast state is per-feature (three independent bools) — no shared toast feature; the
+  duplication is tiny and keeps the features decoupled (prefer duplication over
+  premature abstraction).
+
+## Technical Details
+- New reducer surface (same shape in all three features):
+  - State: `var showsCopiedIDToast = false`
+  - Actions: `.copyIDButtonTapped(id: String)` (chat: `.copySessionIDTapped`, no
+    payload — reads `state.sessionKey`), `.copiedIDToastExpired`
+  - CancelID: `.copyIDToast` (chat: new case in the existing `CancelID` enum —
+    distinct from the code-block `copyFeedback`)
+  - Reduction: set `showsCopiedIDToast = true`, `.run` → `pasteboard.copy(id)` +
+    clock sleep 1.5s → send expiry; expiry sets the bool back to `false` (animated).
+- Views: add `Button("Copy ID", systemImage: "doc.on.doc") { ... }` to
+  - `SessionListView.row(_:)` `.contextMenu` (context menu only — no swipe action),
+  - `ArchivedSessionsView` row `.contextMenu` (next to Restore),
+  - `ChatView` toolbar `Menu` (below Rename, `.disabled(store.sessionKey == nil)`);
+  and a `.overlay(alignment: .bottom)` `CopiedToastView` gated on the store bool on
+  each screen (in chat, keep it above the composer inset).
+- `SessionListFeature.State` / `ArchivedSessionsFeature.State` are public — ensure the
+  new state has a sensible default so existing inits/tests don't break.
+
+## What Goes Where
+- **Implementation Steps** (`[ ]` checkboxes): tasks achievable within this codebase - code changes, tests, documentation updates
+- **Post-Completion** (no checkboxes): items requiring external action - manual testing, changes in consuming projects, deployment configs, third-party verifications
+
+## Implementation Steps
+
+### Task 1: SessionListFeature — Copy ID action + toast state
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift`
+
+- [ ] add `showsCopiedIDToast` state, `.copyIDButtonTapped(id:)` / `.copiedIDToastExpired` actions, `CancelID.copyIDToast`
+- [ ] reduce: `pasteboard.copy(id)` + 1.5s `continuousClock` sleep → expiry (cancelInFlight), expiry clears the bool
+- [ ] write TestStore test: tap → pasteboard captured id + toast shown; TestClock advance → toast hidden
+- [ ] write TestStore test: second copy while toast visible restarts the timer (no early dismiss)
+- [ ] run tests - must pass before task 2
+
+### Task 2: ArchivedSessionsFeature — Copy ID action + toast state
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ArchivedSessionsFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ArchivedSessionsFeatureTests.swift`
+
+- [ ] mirror Task 1's state/actions/effect in `ArchivedSessionsFeature`
+- [ ] write TestStore test: copy → pasteboard capture + toast, clock advance → dismiss
+- [ ] run tests - must pass before task 3
+
+### Task 3: ChatFeature — Copy session ID action
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatInteractionTests.swift`
+
+- [ ] add `showsCopiedIDToast` state, `.copySessionIDTapped` / `.copiedIDToastExpired` actions, `CancelID.copyIDToast`
+- [ ] reduce: copy `state.sessionKey` (guard non-nil → no-op otherwise) + timed dismiss as in Task 1
+- [ ] write TestStore test: with `storedSessionID` set → copies it, toast shows/auto-hides
+- [ ] write TestStore test: `sessionKey == nil` → no state change, no effect
+- [ ] run tests - must pass before task 4
+
+### Task 4: Views — CopiedToastView + menu items on all three screens
+
+**Files:**
+- Create: `HermesMobile/Sources/Features/CopiedToastView.swift`
+- Modify: `HermesMobile/Sources/Features/SessionListView.swift`
+- Modify: `HermesMobile/Sources/Features/ArchivedSessionsView.swift`
+- Modify: `HermesMobile/Sources/Features/Chat/ChatView.swift`
+- Modify: `HermesMobileTests/SessionSnapshotTests.swift`
+
+- [ ] create `CopiedToastView` (capsule + material, "Session ID copied", reduce-motion-aware transition)
+- [ ] add "Copy ID" to the session-list row `.contextMenu` + bottom-overlay toast gated on `store.showsCopiedIDToast`
+- [ ] add "Copy ID" to the archived-sessions row `.contextMenu` + toast overlay
+- [ ] add "Copy ID" to the chat toolbar `Menu` (`.disabled(store.sessionKey == nil)`) + toast overlay above the composer
+- [ ] run `tuist generate` so the new source file is picked up
+- [ ] add snapshot test: sessions list with toast visible; `make snapshot-record` then `make snapshot`
+- [ ] run full snapshot suite - must pass before task 5
+
+### Task 5: Verify acceptance criteria
+- [ ] verify all three menus offer "Copy ID" and copy the correct id
+- [ ] verify edge cases: chat with no session yet (disabled item), rapid re-copy restarts toast
+- [ ] run full test suite: `script -q /dev/null swift test --package-path HermesKit`
+- [ ] run snapshot tests: `make snapshot`
+
+### Task 6: [Final] Update documentation
+- [ ] update CLAUDE.md only if a new reusable pattern emerged (toast) — one line at most
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+*Items requiring manual intervention or external systems - no checkboxes, informational only*
+
+**Manual verification**:
+- on device/simulator: long-press a session row → Copy ID → toast appears and the
+  pasteboard holds the id; same from the Archived sheet and the chat ellipsis menu;
+  VoiceOver announces the menu items sensibly.

--- a/docs/plans/20260724-message-copy-branch-buttons.md
+++ b/docs/plans/20260724-message-copy-branch-buttons.md
@@ -1,0 +1,283 @@
+# Message Copy + Branch-in-New-Chat Buttons (issue #34)
+
+## Overview
+
+Add a per-message action row under completed **assistant** messages with two buttons:
+
+1. **Copy** — copies the message's raw Markdown to the clipboard (surfaces the existing
+   long-press context-menu action as a visible affordance, with checkmark feedback).
+2. **Branch in new chat** — desktop-parity branch: creates a **new session seeded with
+   only that message's text** via `session.create` (`messages` seed +
+   `parent_session_id`), then opens the new chat. No dedicated branch RPC exists —
+   the desktop (upstream `main`, ~v0.17) does exactly this.
+
+Additionally, the session list must display branch sessions **nested under their
+parent** (desktop-style `└─`/`├─` elbow + indent), driven by the `parent_session_id`
+field already present in the REST `GET /api/sessions` payload.
+
+## Context (from discovery)
+
+Verified against hermes-agent upstream `main` (fast-forwarded 2026-07-24) and the
+mobile codebase:
+
+- **Desktop branch mechanics** (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts:1058-1171`):
+  per-message `GitForkIcon` button → `session.create` with
+  `{cols, source: 'desktop', cwd?, messages: [{content, role}], parent_session_id}` —
+  **no `title`** (server auto-titles on first submit via the LLM titler;
+  `get_next_title_in_lineage` only disambiguates collisions). Seeds **only the selected
+  message** (`slice(at, at+1)`). Client shows an optimistic list row titled
+  `"draft: branch #N"` (literal i18n string, N = sibling count + 1).
+- **Server side** (`tui_gateway/server.py:6158-6307`): `session.create` stores
+  `parent_session_id` in memory; the DB row is created **lazily on first prompt**
+  (`_ensure_session_db_row`, stamps `parent_session_id` + `model_config._branched_from`,
+  backfills cwd from parent). Seed transcript is persisted on first submit.
+  ⇒ **A branch that never receives a prompt has no DB row and won't appear in the
+  session list.** Old agents ignore the unknown `messages`/`parent_session_id` params
+  silently (no `-32601` — the method exists), degrading to a plain empty chat.
+- **Parent link on the wire**: REST `GET /api/sessions` rows carry `parent_session_id`
+  (compact projection includes it). Gateway `session.list` does NOT — mobile's list is
+  REST-fed, so we're fine.
+- **Desktop nesting** (`apps/desktop/src/lib/session-branch-tree.ts`): pure client-side
+  flatten — group children by `parent_session_id` within the rendered slice, siblings
+  sorted by recency, a parent group sorts by its freshest member, recursive
+  branch-of-branch, elbow stem `'└─ '` (last sibling) / `'├─ '`, children indented and
+  non-reorderable. **Orphans** (parent archived/absent from the slice) de-nest to normal
+  top-level rows — nothing is hidden.
+- **No chat-side branch indicators** on desktop (no "branched from" back-link, no marker
+  in the parent transcript) — sidebar nesting is the only expression of the relation.
+- **Mobile pieces already in place**: `ChatFeature.copyRow(id:)` +
+  `PasteboardClient` (`ChatFeature.swift:908-910`), triggered today from
+  `.contextMenu` (`ChatView.swift:152-154`); `ChatRow.copyText` returns raw Markdown for
+  message rows; checkmark-feedback pattern exists for code blocks
+  (`recentlyCopiedToken` + 1.5s expiry, `ChatFeature.swift:912-924`); profile threading
+  convention for `session.create` (omit `profile` for `"default"`); `AppFeature`
+  live-chat slot rules (slot replacement must run `teardownSlot`; navigation via
+  `openSession`).
+
+Files involved:
+- `HermesKit/Sources/HermesKit/Models/Session.swift`, `Clients/HermesRESTClient.swift`
+  (SessionListDTO) — decode `parent_session_id`
+- `HermesKit/Sources/HermesKit/Models/SessionBranchTree.swift` (new) — pure flatten
+- `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift` — sectioned rows with stems
+- `HermesKit/Sources/HermesKit/Features/ChatFeature.swift` — copy feedback + branch action
+- `HermesKit/Sources/HermesKit/Features/AppFeature.swift` (wherever `openSession` lives) — open-branch routing
+- `HermesMobile/Sources/Features/Chat/ChatView.swift` (+ new `MessageActionBar.swift`) — action row UI
+- `HermesMobile/Sources/Features/SessionListView.swift` — nested row rendering
+- `HermesMobileTests/` — snapshot tests
+
+## Development Approach
+
+- **Testing approach**: Regular (implement, then tests in the same task) — matches the
+  repo's existing style; TCA `TestStore` + dependency overrides + `TestClock` per
+  project conventions.
+- Complete each task fully before moving to the next; small focused changes.
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+  — success and error scenarios, new code paths, updated expectations when behavior
+  changes. Tests are a required deliverable, not optional.
+- **CRITICAL: all tests must pass before starting the next task** — no exceptions.
+- **CRITICAL: update this plan file when scope changes during implementation.**
+- Run tests after each change (`script -q /dev/null swift test --package-path HermesKit`
+  for live output, or `make test`).
+- Maintain backward compatibility: old agents without seed support degrade to a plain
+  empty chat (accepted; no capability gate — params are silently ignored, not `-32601`).
+
+## Testing Strategy
+
+- **Unit tests** (HermesKit `swift test`): required for every task — DTO decoding,
+  `flattenSessionsWithBranches`, reducer flows (copy feedback, branch guards/success/
+  failure, list sectioning with stems).
+- **Snapshot tests** (`make snapshot` / `make snapshot-record` in `HermesMobileTests`):
+  message action row under an assistant message; session list with a nested branch row
+  (elbow + indent). Re-record only for intentional UI changes; timestamps pinned.
+- No e2e suite in this project.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately when done.
+- Add newly discovered tasks with ➕ prefix; blockers with ⚠️ prefix.
+- Keep the plan in sync with actual work; commit at each task completion (per repo
+  convention), messages: capitalized verb, no conventional-commit prefixes.
+
+## Solution Overview
+
+- **Copy**: a visible `MessageActionBar` under completed assistant rows reuses the
+  existing `.copyRow` reducer path; feedback generalizes the `recentlyCopiedToken`
+  mechanism so the copy icon swaps to a checkmark for ~1.5s.
+- **Branch**: `.branchFromMessage(id:)` in `ChatFeature` — guards (turn not running,
+  non-empty text, session exists), then a **one-shot** `session.create` RPC (convention:
+  outbound RPCs are discrete one-shot effects) with the single-message seed +
+  `parent_session_id` + threaded `profile`. Success emits a delegate
+  (`.branchCreated(sessionID:)`) that `AppFeature` routes through the existing
+  `openSession` slot-replacement flow (`teardownSlot` → push marker — the nil-out is
+  mandatory per slot rules). Failure sets `errorBanner` (never a swallowed `try?`).
+  **No confirmation dialog** (desktop parity; non-destructive — worst case the user
+  archives the branch).
+- **List nesting**: decode `parent_session_id` → pure
+  `flattenSessionsWithBranches(_:)` helper in HermesKit mirroring the desktop
+  algorithm; applied per rendered lane (pinned / workspace groups / chronological)
+  **after** the cron partition. Search and the archived sheet stay flat (matches the
+  desktop's "nesting only within the rendered slice" behavior; orphans de-nest).
+- **No optimistic list insert** (v1 simplification vs desktop): after branching we
+  navigate straight into the new chat; the server has no DB row until the first prompt,
+  so the list simply shows the branch (nested) once it exists server-side, via the
+  normal refetch/poll. Documented behavior: a branch abandoned before any prompt
+  never appears in the list.
+
+## Technical Details
+
+- **Branch RPC params** (mirror the existing `session.create` call byte-for-byte and
+  add): `messages: [["role": "assistant", "content": <ChatRow copyText>]]`,
+  `parent_session_id: <current stored session id>`; `profile` threaded per convention
+  (omitted for `"default"`); do NOT add a `source` param unless the existing create
+  already sends one (a novel source id would leak into the desktop sidebar's
+  source-grouping).
+- **`Session.parentSessionID: String?`** decoded from `parent_session_id` (lenient —
+  absent on old agents → `nil`, never fails decode).
+- **`SessionBranchEntry`** = `(session: Session, branchStem: String?)`; stems are
+  `"└─ "` / `"├─ "`; children sorted by recency; parent-group recency = freshest
+  member; recursion for branch-of-branch; cycle-safe (visited set); trailing sweep so
+  no session is ever dropped.
+- **Row identity/IDs unchanged** — nesting is display-only; pin/archive/rename/swipe
+  affordances keep working on branch rows (a pinned branch renders de-nested in the
+  Pinned lane because its parent isn't in that slice).
+- **Copy feedback state**: reuse/generalize `recentlyCopiedToken: String?` with a
+  row-scoped token (e.g. `"row:<id>"`), same 1.5s `continuousClock` expiry +
+  `cancelInFlight` so the latest copy owns the feedback.
+- **Action-row visibility**: only on `.message(role: .assistant, isComplete: true)`
+  rows; hidden while the row is streaming. Buttons are plain small secondary-tinted
+  icons (`document.on.document`, `arrow.triangle.branch`), always visible (no hover on
+  iOS), respecting the bubble-less assistant layout.
+
+## What Goes Where
+
+- **Implementation Steps** (`[ ]`): all code/test/doc changes in this repo.
+- **Post-Completion** (no checkboxes): manual device verification, upstream/desktop
+  observations, issue bookkeeping.
+
+## Implementation Steps
+
+### Task 1: Decode parent_session_id onto Session
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Models/Session.swift`
+- Modify: `HermesKit/Sources/HermesKit/Clients/HermesRESTClient.swift` (SessionListDTO)
+- Modify: `HermesKit/Tests/HermesKitTests/` (session decoding tests)
+
+- [ ] add `parentSessionID: String?` to `Session` (public init update; lenient decode)
+- [ ] map `parent_session_id` in `SessionListDTO` → `Session`
+- [ ] write tests: payload with `parent_session_id` decodes it; payload without → `nil` (old-agent compat)
+- [ ] run tests - must pass before task 2
+
+### Task 2: SessionBranchTree flatten helper
+
+**Files:**
+- Create: `HermesKit/Sources/HermesKit/Models/SessionBranchTree.swift`
+- Create: `HermesKit/Tests/HermesKitTests/SessionBranchTreeTests.swift`
+
+- [ ] implement `flattenSessionsWithBranches(_ sessions: [Session]) -> [SessionBranchEntry]` mirroring the desktop algorithm (children grouped by `parentSessionID`, sibling recency sort, group-recency lift, recursive nesting, `└─`/`├─` stems, trailing sweep)
+- [ ] handle orphans (parent absent from slice → de-nest, no stem) and self/cycle references safely
+- [ ] write tests: nested ordering, last-vs-middle sibling stems, branch-of-branch, orphan de-nest, cycle safety, empty/flat input passthrough, group recency lift
+- [ ] run tests - must pass before task 3
+
+### Task 3: SessionListFeature emits stemmed entries per lane
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/SessionListFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift`
+
+- [ ] apply `flattenSessionsWithBranches` inside the computed section state (pinned / workspace groups / chronological), after the cron partition — cron lanes and `unmatchedCronSessions` stay flat
+- [ ] keep search results flat (existing convention) and leave `ArchivedSessionsFeature` untouched
+- [ ] write tests: a branch renders nested under its parent in the correct lane; a pinned branch de-nests in the Pinned lane; search stays flat
+- [ ] run tests - must pass before task 4
+
+### Task 4: SessionListView nested row rendering
+
+**Files:**
+- Modify: `HermesMobile/Sources/Features/SessionListView.swift`
+- Modify: `HermesMobileTests/` (session list snapshot tests)
+
+- [ ] render the stem as a monospaced caption in quaternary/tertiary color + leading indent on stemmed rows (row content, swipe actions, context menu unchanged)
+- [ ] run `tuist generate` if any new source file was added
+- [ ] write/update snapshot tests: list with one parent + two branch children (stems `├─`, `└─`); re-record intentionally changed list snapshots
+- [ ] run `make snapshot` + full `swift test` - must pass before task 5
+
+### Task 5: Row-copy checkmark feedback in ChatFeature
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] generalize the copy-feedback state so `.copyRow` sets a row-scoped token (e.g. `"row:<id>"`) with the same 1.5s clock expiry + `cancelInFlight` semantics as `.copyCode`
+- [ ] write tests: copy sets token + pasteboard receives raw Markdown; token clears after 1.5s via `TestClock`; re-copy restarts the timer; empty-text row is a no-op
+- [ ] run tests - must pass before task 6
+
+### Task 6: branchFromMessage action + delegate in ChatFeature
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] add `.branchFromMessage(id: ChatRow.ID)`: guard completed assistant row with non-empty text, guard no running turn (mirror desktop's "stop the current turn first" → set `errorBanner` when running), guard a live/stored session id exists
+- [ ] one-shot `session.create` effect with the single-message seed + `parent_session_id` + threaded `profile` (byte-identical to the existing create otherwise; `[gateway]` captured explicitly)
+- [ ] on success emit `Delegate.branchCreated(sessionID:)`; on failure set `errorBanner` and clear any in-flight flag (no swallowed `try?`)
+- [ ] add a double-fire guard (in-flight flag) so a second tap is a no-op while the RPC runs
+- [ ] write tests: success path (RPC params asserted incl. seed + parent + profile-omitted-for-default, delegate emitted), failure → errorBanner, running-turn guard, empty-text guard, double-tap guard
+- [ ] run tests - must pass before task 7
+
+### Task 7: AppFeature routes branchCreated through the slot flow
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/AppFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/AppFeatureTests.swift`
+
+- [ ] handle `.liveChat(.delegate(.branchCreated(sessionID:)))`: open the new session via the existing `openSession`/slot-replacement policy (`teardownSlot` → `.clearLiveChat` → new slot + path marker — never swap slot state directly)
+- [ ] trigger a session-list refetch so the branch shows (nested) once its DB row exists
+- [ ] write tests: branch from the open slot replaces the slot and sets the path to the single new marker; list reload requested
+- [ ] run tests - must pass before task 8
+
+### Task 8: MessageActionBar UI in ChatView
+
+**Files:**
+- Create: `HermesMobile/Sources/Features/Chat/MessageActionBar.swift`
+- Modify: `HermesMobile/Sources/Features/Chat/ChatView.swift`
+- Modify: `HermesMobileTests/` (chat snapshot tests)
+
+- [ ] build `MessageActionBar` (copy button with checkmark-swap driven by the row token; branch button `arrow.triangle.branch`) — small secondary-tinted icons, leading-aligned under the assistant text, a11y labels
+- [ ] show it only under completed assistant `.message` rows in `rowView`; keep the existing context-menu copy
+- [ ] disable/hide branch while the turn is running (mirror the reducer guard for instant affordance feedback)
+- [ ] run `tuist generate` (new source file)
+- [ ] write snapshot tests: completed assistant message with action bar; copied state (checkmark); streaming row without the bar
+- [ ] run `make snapshot` + full test suite - must pass before task 9
+
+### Task 9: Verify acceptance criteria
+
+- [ ] verify all Overview requirements: visible copy with feedback, branch creates seeded session and opens it, session list nests branches with elbow stems, orphans de-nest
+- [ ] verify edge cases: old-agent degradation (params ignored → empty chat opens, no crash), running-turn guard, empty-text guard, branch-of-branch rendering
+- [ ] run full suite: `script -q /dev/null swift test --package-path HermesKit`
+- [ ] run `make snapshot`
+- [ ] build the app target (`tuist generate` + xcodebuild) to confirm the new view files compile
+
+### Task 10: [Final] Update documentation
+
+- [ ] add the message-action-row + branch conventions to `CLAUDE.md` (branch = desktop-parity `session.create` seed; list nesting is display-only client-side flatten)
+- [ ] update `README.md` feature list if it enumerates chat features
+- [ ] close the loop on issue #34 (comment with what shipped)
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification:**
+- On-device: branch from an assistant message against a live agent; confirm the new
+  chat opens seeded with that message, the server auto-title lands after the first
+  prompt, and the session list shows the nested row on next refresh.
+- Verify against an older agent build (no seed support): branch yields an empty new
+  chat, no error, no crash.
+- VoiceOver pass on the action bar.
+
+**External observations (no action in this repo):**
+- Desktop shows an optimistic `"draft: branch #N"` row immediately; mobile v1
+  deliberately skips optimistic insert — a branch abandoned before any prompt never
+  materializes server-side. If that feels off in practice, a follow-up issue can add
+  the optimistic row.
+- A "branched from …" back-link inside the chat does not exist on desktop either; if
+  wanted, it needs `parent_session_id` surfaced on `session.resume` info — upstream ask.

--- a/docs/plans/20260724-slash-commands.md
+++ b/docs/plans/20260724-slash-commands.md
@@ -1,0 +1,382 @@
+# Slash-Command Support in the Chat Composer
+
+GitHub issue: #36
+
+## Overview
+
+Support the agent's slash commands from the mobile chat composer, mirroring desktop:
+typing `/` surfaces a filtering autocomplete panel of available commands (built-ins +
+dynamic skill routes), selection inserts the command, and sending executes it through
+the gateway's dedicated slash pipeline (`slash.exec` → `command.dispatch` →
+`prompt.submit` for skill/send directives) — **not** as plain prompt text. Command
+output renders as a new bubble-less transcript row. The whole affordance is
+capability-gated: old agents without `commands.catalog` behave byte-identically to
+today.
+
+Key benefit: mid-conversation session control from the phone (`/compress`, `/undo`,
+`/retry`, `/steer`, `/queue`, `/status`, …) plus invoking installed skills (`/plan`,
+…) — none of which have native mobile UI.
+
+## Context (from discovery)
+
+Protocol facts verified in the Hermes source clone
+(`/Users/eugene/Documents/Development/Personal/hermes-agent`):
+
+- **Discovery is WS JSON-RPC only** (no REST endpoint): `commands.catalog`
+  (`tui_gateway/server.py:13871`) returns
+  `{pairs: [[name, desc]], sub: {"/cmd": [subs]}, canon: {alias: canonical}, categories: [{name, pairs}], skill_count, warning}`.
+  Dynamic skill routes are appended to `pairs` only (never in `categories`).
+- **Execution**: `slash.exec {command, session_id}` → `{output, warning?}`
+  (`server.py:15746`); on error fall back to `command.dispatch {name, arg, session_id}`
+  → typed directive `{type:'exec'|'plugin', output}` / `{type:'alias', target}` /
+  `{type:'skill'|'send', message}` — skill/send messages then go through the normal
+  `prompt.submit` (`server.py:14060`). Reference pipeline: `web/src/lib/slashExec.ts`
+  (explicitly written for future SwiftUI clients to copy).
+- The catalog is TUI-flavored: excludes messaging-only commands but **includes
+  terminal-only ones**; no surface flags on the wire. Desktop filters client-side
+  (`apps/desktop/src/lib/desktop-slash-commands.ts`) — mobile does the same.
+- **Verified: `slash.exec` output is ephemeral** — never written to persisted history;
+  `session.resume` never returns it; desktop and web both accept output loss on
+  reload.
+
+Mobile codebase anchors:
+
+- `HermesKit/Sources/HermesKit/Features/ChatFeature.swift` — `composerText` (~38),
+  `BindingReducer` (~428), `composerSubmitted` handler (~679–768, `prompt.submit`
+  ~764), attach capability pattern (`isUnknownMethod` catch ~731–734 →
+  `attachmentsUnsupportedDetected` ~1099–1109), `model.options` fetch convention
+  (~1120–1136).
+- `HermesKit/Sources/HermesKit/Clients/HermesGatewayClient.swift` — `send` (~25),
+  `GatewayError.isUnknownMethod` (~53–61).
+- `HermesMobile/Sources/Features/Chat/ChatView.swift` — stack: connectionBanner →
+  transcript → footer → pendingCard → `Divider()` → `ComposerView` (~18–40).
+- `HermesMobile/Sources/Features/Chat/ComposerView.swift` — `attachmentChips` above
+  the TextField (~72–81) prove the "strip above composer" slot.
+
+## Development Approach
+
+- **Testing approach**: Regular (code first, then tests, within each task)
+- Complete each task fully before moving to the next; small focused changes
+- **Commit at each task completion** (per project memory) — capitalized verb, no
+  conventional-commit prefixes, concise
+- **CRITICAL: every task MUST include new/updated tests** — success and error paths,
+  listed as separate checklist items; not optional
+- **CRITICAL: all tests must pass before starting the next task**
+- **CRITICAL: update this plan file when scope changes during implementation**
+- Backward compatibility is a hard guard: agents without `commands.catalog` must see
+  byte-identical behavior to today
+
+## Testing Strategy
+
+- **Unit tests (HermesKit, `swift test`)**: pure decode + filter logic, and
+  `TestStore` reducer tests for every new action path (highest-value suite per
+  project conventions). Use
+  `script -q /dev/null swift test --package-path HermesKit` (or `make test`) for
+  live output.
+- **Snapshot tests (`HermesMobileTests`)**: the suggestion panel and the
+  command-output row. `make snapshot` to assert, `make snapshot-record` to record
+  new baselines. Row timestamps pinned for determinism.
+- No e2e suite in this project.
+
+## Progress Tracking
+
+- Mark completed items `[x]` immediately when done
+- Add newly discovered tasks with ➕ prefix
+- Document issues/blockers with ⚠️ prefix
+- Keep the plan in sync with actual work
+
+## Solution Overview
+
+Locked design decisions (from the 2026-07-24 brainstorm):
+
+1. **Curation — mirror desktop**: show the full catalog minus a static client-side
+   `mobileHiddenCommands` hide-list of terminal-only commands. Redundant-with-native-UI
+   commands (`/model`, `/stop`, `/new`, `/title`, `/sessions`, `/resume`, `/usage`,
+   `/reasoning`) ARE shown for muscle-memory parity.
+2. **Filtering — client-side only** over the cached catalog. NO `complete.slash` in
+   v1 (server arg-completion is a possible follow-up).
+3. **UI — inline suggestion panel** between transcript and composer, ~5 visible rows
+   with internal scroll, monospaced name + secondary description, skill rows marked
+   with an icon, reduce-motion-respecting transition, tap inserts and keeps the
+   keyboard up.
+4. **No new dependency client** — catalog fetch is a one-shot
+   `gateway.send("commands.catalog", …)` effect in `ChatFeature` (the `model.options`
+   convention). Capability gate = the attach pattern verbatim.
+5. **No stored suggestion state** — a computed property derives suggestions from
+   `composerText` + `commandCatalog` via a pure filter. Nothing to keep in sync.
+6. **Ephemerality (desktop parity)** — command rows are local-only and vanish on the
+   next wholesale hydrate; NO #26-style preservation for them (skill/send invocations
+   persist naturally as real `prompt.submit` messages). NO full hydrate after exec
+   (it would wipe the output row) — instead a **runtime-only refresh**
+   (`session.resume` → `applyRuntimeInfo` only, transcript untouched).
+
+## Technical Details
+
+### CommandCatalog model (HermesKit)
+
+```swift
+public struct SlashCommand: Equatable, Sendable {
+    public let name: String        // "/compress" (canonical, leading slash)
+    public let description: String
+    public let category: String?   // "Session" … nil for skills
+    public let isSkill: Bool
+}
+public struct CommandCatalog: Equatable, Sendable {
+    public let commands: [SlashCommand]        // hide-list already applied, category order, skills last
+    public let subcommands: [String: [String]] // "/reasoning" → ["none", "low", …]
+    public let canonical: [String: String]     // "/reset" → "/new"
+}
+```
+
+- Decoded leniently from the `commands.catalog` JSON — unknown/missing fields never
+  throw (same rule as events).
+- `categories` gives categorized built-ins; entries in `pairs` appearing in **no**
+  category are the appended skill routes → `isSkill = true`.
+- `mobileHiddenCommands: Set<String>` (static, unit-tested) applied at decode:
+  `/clear /redraw /history /prompt /snapshot /config /statusbar /timestamps /skin
+  /indicator /busy /copy /paste /image /quit /handoff /tools /toolsets /pet /hatch
+  /reload /reload-mcp /reload-skills /browser /plugins /billing /platforms /journey`.
+
+### SlashSuggestionFilter (pure)
+
+`SlashSuggestionFilter.suggestions(for: composerText, catalog:) -> [SlashSuggestion]`:
+
+- Text must **begin with `/`** and contain no newline — else `[]` (mid-sentence
+  slashes never trigger).
+- Bare `/` → full filtered catalog in category order, skills last.
+- First token, no space yet (`/qu`) → case-insensitive **prefix** match on canonical
+  names AND aliases (via `canonical`; matched aliases display their canonical row).
+  Prefix-only, no fuzzy.
+- Known command + space + partial (`/reasoning l`) → subcommand suggestions from the
+  `sub` map. Any other post-space text → `[]` (args are freeform).
+
+### ChatFeature changes
+
+- State: `commandCatalog: CommandCatalog?`, `commandsUnsupported: Bool`, computed
+  `slashSuggestions`.
+- Catalog fetch: one-shot effect after hydrate reaches ready;
+  `isUnknownMethod` → `commandsUnsupported = true` (attach pattern); transient
+  failure → catalog stays `nil`, silent, retried on next hydrate.
+- `.slashSuggestionTapped` → sets `composerText = "/name "` (trailing space) or
+  `"/cmd sub"`; suggestions update/clear automatically via the computed property.
+- `composerSubmitted` command branch — only when trimmed text starts with `/` AND
+  catalog is loaded AND no staged attachments (attachments always take the plain
+  prompt path): append the typed command as a normal **user row**, clear composer,
+  set `isSending`. Effect chain:
+  1. `slash.exec {command (no leading slash), session_id}` → `{output, warning?}` →
+     append a `commandOutput` row, clear `isSending`, then **runtime-only refresh**.
+  2. `slash.exec` error → `command.dispatch {name, arg, session_id}`:
+     `exec`/`plugin` → output row (as above); `alias` → re-enter the pipeline once
+     with the target (**single hop**, no loop); `skill`/`send` → hand `message` to
+     the existing `prompt.submit` flow **suppressing the duplicate optimistic user
+     row** (the `/cmd` row is already in the transcript) — streaming/thinking takes
+     over and `isSending` follows the normal turn lifecycle.
+  3. Both fail → `errorBanner` + clear `isSending` (never a swallowed `try?`). The
+     session-not-found self-heal wraps these RPCs like any other outbound call.
+- Runtime-only refresh: `session.resume(sessionID)` applying `applyRuntimeInfo`
+  (model/reasoning/usage/title) **without** `reconstructTranscript`/inflight seeding;
+  failure is silent (cosmetic refresh only).
+
+### commandOutput row
+
+New `ChatRow.Kind.commandOutput(String)`: bubble-less, dimmed system styling,
+monospaced, selectable. Own stable kind-discriminator token feeding the FNV-1a
+deterministic row ID (never random, never derived from mutable text).
+
+## What Goes Where
+
+- **Implementation Steps** (checkboxes): all code, tests, and doc updates in this
+  repo.
+- **Post-Completion** (no checkboxes): manual on-device verification against a live
+  agent; nothing in external repos (no agent/plugin/gateway changes).
+
+## Implementation Steps
+
+### Task 1: CommandCatalog model with lenient decode and mobile hide-list
+
+**Files:**
+- Create: `HermesKit/Sources/HermesKit/Models/CommandCatalog.swift`
+- Create: `HermesKit/Tests/HermesKitTests/CommandCatalogTests.swift`
+
+- [ ] add `SlashCommand` + `CommandCatalog` structs (public, `Equatable`, `Sendable`)
+- [ ] implement lenient decode from the `commands.catalog` JSON response
+      (`pairs`/`sub`/`canon`/`categories`): categorized pairs keep their category,
+      uncategorized pairs → `isSkill = true` appended last; malformed/missing fields
+      degrade, never throw
+- [ ] add static `mobileHiddenCommands: Set<String>` (list in Technical Details) and
+      apply it at decode (also drop hidden names from `subcommands`/`canonical`)
+- [ ] write tests: full fixture decode (categories, skills marked, hide-list
+      applied, aliases mapped, subcommands mapped)
+- [ ] write tests: malformed/empty/partial payloads decode leniently without throwing
+- [ ] run `swift test --package-path HermesKit` — must pass before task 2
+
+### Task 2: SlashSuggestionFilter pure filtering logic
+
+**Files:**
+- Create: `HermesKit/Sources/HermesKit/Models/SlashSuggestionFilter.swift`
+- Create: `HermesKit/Tests/HermesKitTests/SlashSuggestionFilterTests.swift`
+
+- [ ] add `SlashSuggestion` (id/name/description/isSkill or subcommand variant —
+      whatever the panel needs, `Equatable`) and
+      `SlashSuggestionFilter.suggestions(for:catalog:)` implementing the rules in
+      Technical Details (leading-`/` + no-newline guard, bare `/` full list, prefix
+      match on names + aliases, subcommand mode after `/cmd `, `[]` otherwise)
+- [ ] write tests: bare `/` → full list in category order with skills last; `/qu`
+      prefix filtering; alias lookup (`/fork` → `/branch` row); case-insensitivity
+- [ ] write tests: subcommand mode (`/reasoning l` → `low`); freeform args → `[]`;
+      mid-sentence `/` and multiline text → `[]`; nil catalog → `[]`
+- [ ] run `swift test --package-path HermesKit` — must pass before task 3
+
+### Task 3: Catalog fetch and capability gate in ChatFeature
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] add `commandCatalog: CommandCatalog?` + `commandsUnsupported: Bool` to State
+      and actions `.commandCatalogLoaded(CommandCatalog)` /
+      `.commandsUnsupportedDetected`
+- [ ] fire a one-shot `gateway.send("commands.catalog", …)` effect once hydrate
+      reaches ready (mirror the `model.options` convention; `[gateway]` capture per
+      `@Sendable` gotcha); decode via Task 1
+- [ ] on `GatewayError.isUnknownMethod` → `.commandsUnsupportedDetected` (attach
+      pattern verbatim); any other failure → silent no-op (catalog stays `nil`,
+      naturally retried on next hydrate); skip the fetch when `commandsUnsupported`
+- [ ] write TestStore tests: successful fetch populates the catalog; unknown-method
+      flips `commandsUnsupported` and suppresses future fetches
+- [ ] write TestStore tests: transient failure leaves catalog `nil` and a later
+      hydrate refetches
+- [ ] run `swift test --package-path HermesKit` — must pass before task 4
+
+### Task 4: Computed suggestions and selection action
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] add computed `State.slashSuggestions` delegating to `SlashSuggestionFilter`
+      (empty when catalog is `nil` or `commandsUnsupported`)
+- [ ] add `.slashSuggestionTapped(SlashSuggestion)` → set `composerText` to
+      `"/name "` (trailing space) or `"/cmd sub"`; no other state changes
+- [ ] write TestStore tests (the issue's required four): typing `/` yields
+      suggestions; typing filters; tap inserts the command; non-`/` input never
+      produces suggestions
+- [ ] write test: suggestions stay empty when `commandsUnsupported`
+- [ ] run `swift test --package-path HermesKit` — must pass before task 5
+
+### Task 5: commandOutput transcript row kind
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Models/ChatRow.swift` (or wherever
+  `ChatRow.Kind` + the FNV-1a discriminator live)
+- Modify: `HermesKit/Tests/HermesKitTests/` (the existing row-ID test file)
+
+- [ ] add `ChatRow.Kind.commandOutput(String)` with its own stable
+      kind-discriminator token for the deterministic ID (extend every exhaustive
+      `switch` the compiler flags)
+- [ ] write tests: commandOutput row IDs are deterministic across rebuilds and
+      distinct from other kinds at the same ordinal
+- [ ] write test: `reconstructTranscript` output is unaffected (server history never
+      contains commandOutput; wholesale replace drops local ones — desktop parity)
+- [ ] run `swift test --package-path HermesKit` — must pass before task 6
+
+### Task 6: slash.exec pipeline in composerSubmitted
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] branch `composerSubmitted`: trimmed text starts with `/` AND catalog loaded
+      AND attachments empty → command branch (append user row, clear composer, set
+      `isSending`); otherwise today's path byte-identical
+- [ ] add the `slash.exec` effect (`{command w/o slash, session_id}`) + response
+      action appending the `commandOutput` row (include `warning` when present) and
+      clearing `isSending`; wrap with the existing session-not-found self-heal
+- [ ] add the runtime-only refresh after successful exec: `session.resume` →
+      `applyRuntimeInfo` only (no transcript touch); silent on failure
+- [ ] write TestStore tests: `/status` submit → user row + exec RPC + output row +
+      `isSending` cycle + runtime refresh applies model/usage without transcript
+      change
+- [ ] write TestStore tests: unsupported/`nil`-catalog agent → `/text` goes through
+      plain `prompt.submit` untouched (backward-compat guard); staged attachments
+      force the plain path
+- [ ] run `swift test --package-path HermesKit` — must pass before task 7
+
+### Task 7: command.dispatch fallback (alias, exec, skill/send directives)
+
+**Files:**
+- Modify: `HermesKit/Sources/HermesKit/Features/ChatFeature.swift`
+- Modify: `HermesKit/Tests/HermesKitTests/ChatFeatureTests.swift`
+
+- [ ] on `slash.exec` failure (non-unknown-method) → `command.dispatch
+      {name, arg, session_id}`; decode the typed directive leniently
+- [ ] handle directives: `exec`/`plugin` → output row (as Task 6); `alias` →
+      re-enter the pipeline once with the target (single hop — a second alias fails
+      to the error path); `skill`/`send` → route `message` into the existing
+      `prompt.submit` flow suppressing the duplicate optimistic user row;
+      `isSending` then follows the normal turn lifecycle
+- [ ] both-fail path → `errorBanner` + clear `isSending` (no swallowed `try?`)
+- [ ] write TestStore tests: dispatch `exec` output row; alias single hop resolves;
+      double-alias hits the error path
+- [ ] write TestStore tests: `skill` directive submits the message with exactly one
+      user row (the typed `/cmd`); both-RPCs-fail → `errorBanner` and composer
+      unlocked
+- [ ] run `swift test --package-path HermesKit` — must pass before task 8
+
+### Task 8: SlashSuggestionPanel view, ChatView wiring, row rendering
+
+**Files:**
+- Create: `HermesMobile/Sources/Features/Chat/SlashSuggestionPanel.swift`
+- Modify: `HermesMobile/Sources/Features/Chat/ChatView.swift`
+- Modify: the chat row view rendering (`rowView` site) for `.commandOutput`
+- Modify: `HermesMobileTests/` (snapshot tests)
+
+- [ ] build `SlashSuggestionPanel(suggestions:onTap:)` — thin view: rows of
+      monospaced name + secondary description, skill icon for `isSkill`, ~5 visible
+      rows max with internal scroll, reduce-motion-respecting transition
+- [ ] slot it in `ChatView` between the transcript and `Divider()`/`ComposerView`,
+      rendered only when `store.slashSuggestions` is non-empty; taps send
+      `.slashSuggestionTapped`; keyboard stays up
+- [ ] render `.commandOutput` rows bubble-less, dimmed, monospaced, selectable
+- [ ] run `tuist generate` so the new source file joins the app target
+- [ ] write snapshot tests: panel with built-ins + a skill row; a commandOutput row;
+      record via `make snapshot-record`
+- [ ] run `make snapshot` — must pass before task 9
+
+### Task 9: Verify acceptance criteria
+
+- [ ] verify the issue's expected behavior end-to-end in tests: `/` opens the list,
+      filtering works, selection inserts, commands submit through the slash
+      pipeline, non-`/` input unaffected
+- [ ] verify backward compat: `commandsUnsupported` path leaves every existing test
+      untouched (no snapshot or reducer diffs outside the new feature)
+- [ ] run the full HermesKit suite:
+      `script -q /dev/null swift test --package-path HermesKit`
+- [ ] run `make snapshot`
+- [ ] build the app: `tuist generate` + simulator build succeeds
+
+### Task 10: [Final] Update documentation
+
+- [ ] add a slash-command convention bullet to `CLAUDE.md` (catalog fetch + gate,
+      client-side filter, exec pipeline, ephemerality rule)
+- [ ] update `README.md` feature list if it enumerates chat features
+- [ ] move this plan to `docs/plans/completed/`
+
+## Post-Completion
+
+**Manual verification** (on-device against a live agent):
+- Type `/` in a real session: panel appears with built-ins + installed skills;
+  `/status` returns output; `/reasoning low` subcommand completion works
+- `/compress` on a long session: output row appears, context pill drops after the
+  runtime refresh
+- A skill route (e.g. `/plan …`): streams as a normal turn, single user row
+- Old-agent regression check (or simulated `-32601`): no panel, plain sends
+  unchanged
+- Confirm command output visibly disappearing after backgrounding/re-hydrate feels
+  acceptable (known desktop-parity behavior, documented above)
+
+**Possible follow-ups** (out of scope):
+- `complete.slash` server-driven argument completion (checkpoint ids, personality
+  names)
+- Command palette entry point (a `/` button in the composer toolbar) if
+  discoverability turns out poor

--- a/docs/plans/completed/20260724-cold-launch-push-tap-replay.md
+++ b/docs/plans/completed/20260724-cold-launch-push-tap-replay.md
@@ -172,18 +172,20 @@
 
 ### Task 4: Verify acceptance criteria
 
-- [ ] verify both drop sites from issue #46 are closed (bridge buffer + reducer replay)
-- [ ] verify edge cases: tap for the session already in the slot after replay (slot-match
+- [x] verify both drop sites from issue #46 are closed (bridge buffer + reducer replay)
+- [x] verify edge cases: tap for the session already in the slot after replay (slot-match
       short-circuit still applies — replay goes through the same `.pushTapped` case);
       non-approval tap replay; approval badge netting
-- [ ] run full test suite: `script -q /dev/null swift test --package-path HermesKit`
-- [ ] confirm no view changes → snapshot suite untouched, no re-record needed
+- [x] run full test suite: `script -q /dev/null swift test --package-path HermesKit`
+      (741 tests in 49 suites passed)
+- [x] confirm no view changes → snapshot suite untouched, no re-record needed
+      (diff vs main touches only `HermesKit/Sources`, `HermesKit/Tests`, and this plan)
 
 ### Task 5: [Final] Update documentation
 
-- [ ] update `CLAUDE.md` push-notifications bullet: note the cold-launch tap replay
+- [x] update `CLAUDE.md` push-notifications bullet: note the cold-launch tap replay
       (bridge consume-once buffer + `pendingPushTap` reducer stash)
-- [ ] move this plan to `docs/plans/completed/`
+- [x] move this plan to `docs/plans/completed/`
 
 ## Post-Completion
 *Items requiring manual intervention or external systems — no checkboxes, informational only*


### PR DESCRIPTION
## Summary

Fixes the cold-launch case of push-tap deep-linking: tapping a push for a session the
phone has never loaded (a new cron run, a desktop-started chat) **launches** the app but
lands on the sessions list instead of opening the chat. The warm case already worked
(placeholder `Session(id:)` + `session.resume`); on cold launch the tap was dropped
before routing in two independent places and never replayed.

Closes #46.

## The two drop sites (both closed)

1. **`PushBridge` had no buffer for late subscribers** — on a true launch-from-push the
   app-delegate's `tapReceived` fires before the reducer's `.task` subscribes, so with zero
   continuations the tap was silently discarded. Now the bridge buffers the last undelivered
   tap (`pendingTap`, consume-once) and the first `tapStream()` subscriber drains it — the
   mirror of the existing `lastToken` replay, but cleared after delivery so a stale tap never
   re-navigates a re-subscriber.
2. **`AppFeature.pushTapped` bailed badge-only when `state.home == nil`** — and nothing
   replayed the dropped tap once `home` was created. Now the pre-`home` tap is stashed in
   `AppFeature.State.pendingPushTap` and replayed via the normal `.pushTapped` routing from
   both home-creation sites (`.autoConnectSucceeded` and the manual-login
   `.onboarding(.delegate(.connected))`), so slot dedup (#32), approval-hint arming (#30),
   and the placeholder-session fallback are all reused rather than duplicated.

No push-payload change (generic-body privacy rule untouched); no plugin or gateway change.

## Implementation notes

- `PushBridge` moved outside the `#if canImport(UIKit)` guard (Foundation-only: `NSLock` +
  `AsyncStream`) so the buffering is unit-testable on macOS via `swift test`. The UIKit
  `liveValue` and app-delegate wiring stay guarded.
- Continuations are UUID-keyed with `onTermination` pruning, so a cancelled/restarted
  `.task` observer can't strand a dead continuation and defeat the buffer; `tapReceived`
  inspects each `yield`'s result and falls back to buffering when no live continuation
  accepted the tap.
- Cold-launch replay seeds the freshly created `SessionListFeature.State` with the persisted
  profile selection (`makeHomeState`), so the replayed `session.resume` is profile-scoped —
  otherwise a non-default-profile user's cron-run tap would resume unscoped and the self-heal
  would recreate an empty session under `default`.
- The stash records the origin server URL and is dropped (not replayed) on a login to a
  *different* server; disconnect / reauth-quit / different-user reauth clear the stash and the
  approval-badge set (identity-scoped teardown).

## Accepted corners (documented in code + CLAUDE.md)

- The push payload carries no server identity (privacy rule), so the stash uses the
  pref-at-stash-time as the origin approximation; a fully-logged-out (nil-origin) stash
  replays unverified, per the "logged out → login → open pushed session" flow. Worst case is
  the same spurious-empty-chat the resume self-heal produces for any unknown id.
- Profile support is inferred from a persisted non-default profile name; a deleted/renamed
  profile could resume the wrong DB. This is deliberate parity with the warm list-tap path
  and is bounded by the logout pref-wipe.

## Testing

- `swift test --package-path HermesKit` — **750 tests in 49 suites pass.**
- New coverage: bridge buffering / consume-once / last-wins / re-engage-after-termination,
  both replay paths, the composed bridge+reducer launch race, profile-scoped replay,
  same/different-server replay, cross-server badge scrub, and stash/badge clearing on all
  three identity teardowns.
- No view changes → snapshot suite untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
