### PR TITLE
Fix slash-command alias routing and ANSI output

### DIFF
--- a/HermesKit/Sources/HermesKit/Clients/HermesGatewayClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/HermesGatewayClient.swift
@@ -42,8 +42,12 @@ public struct HermesGatewayClient: Sendable {
   /// reference hit the same wall and budgets 120s for its equivalent `session.compress`
   /// call (`use-prompt-actions/slash.ts`). `command.dispatch` is included because the
   /// gateway routes `/compress`/`/compact` through it (`_PENDING_INPUT_COMMANDS`) and
-  /// because it is this client's `slash.exec` fallback.
-  public static let longRunningMethods: Set<String> = ["slash.exec", "command.dispatch"]
+  /// because it is this client's `slash.exec` fallback. `session.compress` is the DEDICATED
+  /// RPC `/compress`/`/compact` now call directly (bypassing the slash worker for
+  /// version-independent, desktop-parity behavior): its handler runs the same unbounded
+  /// inline LLM summarisation, so it needs the identical 120s budget (the desktop's
+  /// `SESSION_COMPRESS_TIMEOUT_MS`).
+  public static let longRunningMethods: Set<String> = ["slash.exec", "command.dispatch", "session.compress"]
 }
 
 public enum GatewayError: Error, Equatable, Sendable {

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -1082,9 +1082,14 @@ public struct ChatFeature {
           let stored = state.attachLiveSessionID == nil ? state.storedSessionID : nil
           let seed = state.branchSeed
           let profile = state.scopedProfile
+          // Resolve a typed ALIAS to its canonical name for the WIRE command only (#36
+          // follow-up): the gateway's live handler recognizes only canonical names, so a
+          // raw alias (`/compact`) would fall through to the isolated slash-worker and
+          // report "Unknown command". The echoed user row above keeps the RAW typed text.
+          let wireCommand = catalog.canonicalizedCommandText(text)
           return .run { [gateway] send in
             await executeSlashCommand(
-              command: text, sessionID: sessionID, storedSessionID: stored,
+              command: wireCommand, sessionID: sessionID, storedSessionID: stored,
               branchSeed: seed, profile: profile, gateway: gateway, send: send
             )
           }
@@ -1634,7 +1639,9 @@ public struct ChatFeature {
         // draft). The rewound turns are removed from the transcript by the refresh below,
         // which is server-authoritative precisely because the rewind IS a history change.
         if let notice { appendCommandOutput(notice, into: &state) }
-        if !message.isEmpty { state.composerText = message }
+        // The prefilled draft is set straight into the composer (not through
+        // `appendCommandOutput`), so strip ANSI here too (#36 follow-up).
+        if !message.isEmpty { state.composerText = message.strippingANSI }
         return finishSlashExec(refresh: true, into: &state)
 
       case let .slashCommandFailed(message):
@@ -2743,7 +2750,11 @@ public struct ChatFeature {
   /// streaming append (a scrolled-up user is never yanked).
   private func appendCommandOutput(_ text: String, into state: inout State) {
     let wasAtBottomWindow = state.windowStart >= State.bottomWindowStart(count: state.transcript.count)
-    state.transcript.append(ChatRow(id: uuid(), kind: .commandOutput(text: text)))
+    // Strip ANSI/VT100 escapes (#36 follow-up): slash output/warnings/notices are formatted
+    // for a terminal and render as literal garbage on mobile. This is the single chokepoint
+    // for every ephemeral `commandOutput` row (`.slashCommandOutput`, `.slashCommandNotice`,
+    // and the prefill notice), so nothing terminal-formatted leaks into the transcript.
+    state.transcript.append(ChatRow(id: uuid(), kind: .commandOutput(text: text.strippingANSI)))
     maintainWindowAfterStreaming(wasAtBottomWindow: wasAtBottomWindow, into: &state)
   }
 

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -1053,6 +1053,44 @@ public struct ChatFeature {
           state.errorBanner = "Command failed: empty command"
           return .none
         }
+        // The compress family (`/compress` + alias `/compact`) routes to the DEDICATED
+        // `session.compress` gateway RPC — NEVER the generic `slash.exec` pipeline (desktop
+        // parity: `use-prompt-actions/slash.ts`). This detection is BY CANONICAL INTENT — a
+        // hardcoded `compressCommandNames` set matched on the parsed first token — and runs
+        // BEFORE (and independent of) the `resolvesCommand`/canonicalization gate below,
+        // because an OLDER agent's `commands.catalog` mislabels the alias (its `canon`
+        // self-maps `/compact → /compact` instead of `→ /compress`): the client-side
+        // canonicalization is then a no-op and the raw `/compact` would fall through
+        // `slash.exec` to the isolated slash-worker subprocess whose registry can't resolve
+        // the alias → "Unknown command: /compact". `session.compress` (a first-class RPC
+        // since 2026-04-03) sidesteps the worker entirely, so it works version-independently.
+        // Gated on a loaded catalog like the slash branch (a nil-catalog / `commandsUnsupported`
+        // old agent keeps today's byte-identical plain `prompt.submit` path). The RAW typed
+        // `/compress`/`/compact` is echoed as the user row; a typed argument becomes the
+        // compression `focus_topic`.
+        if SlashSuggestionFilter.isCommandShaped(text), state.commandCatalog != nil,
+           compressCommandNames.contains(parseSlashCommand(text).name.lowercased()) {
+          let wasAtBottomWindow = state.windowStart >= State.bottomWindowStart(count: state.transcript.count)
+          state.transcript.append(ChatRow(id: uuid(), kind: .message(role: .user, text: text, isComplete: true)))
+          maintainWindowAfterStreaming(wasAtBottomWindow: wasAtBottomWindow, into: &state)
+          state.composerText = ""
+          state.errorBanner = nil
+          state.isSending = true
+          state.slashExecInFlight = true
+          // Thread storedSessionID/branchSeed/profile through the same #17 session-heal the
+          // slash and prompt paths use (an unpersisted branch heals by recreating from its
+          // client-held seed, not by resuming a row-less stored id).
+          let stored = state.attachLiveSessionID == nil ? state.storedSessionID : nil
+          let seed = state.branchSeed
+          let profile = state.scopedProfile
+          let focusTopic = parseSlashCommand(text).arg
+          return .run { [gateway] send in
+            await executeCompress(
+              focusTopic: focusTopic, sessionID: sessionID, storedSessionID: stored,
+              branchSeed: seed, profile: profile, gateway: gateway, send: send
+            )
+          }
+        }
         // Take the slash pipeline ONLY when the command RESOLVES in the curated catalog (a
         // visible command/skill route or a known alias — `CommandCatalog.resolvesCommand`).
         // A manually-typed HIDDEN command (`/new`, `/quit`, `/branch`, `/yolo`, … — the
@@ -3031,11 +3069,22 @@ func parseSlashCommand(_ command: String) -> (name: String, arg: String) {
 /// An ERROR for one of these is therefore an error from a dispatch that ALREADY RAN, so the
 /// client's `command.dispatch` fallback must be skipped: re-issuing it would re-enter the
 /// same handler a second time. Mostly benign (handlers guard-then-act) but not universally —
-/// a `/compact` that reached the "compress failed" path has already mutated history and
-/// would be re-compressed. Same double-execution class as the transport-failure guard.
+/// a `/retry` that reached its truncate-and-resend path has already mutated history and would
+/// run twice. Same double-execution class as the transport-failure guard.
+///
+/// `compress`/`compact` are deliberately ABSENT: they no longer reach `executeSlashCommand`
+/// at all (routed to the dedicated `session.compress` RPC before the slash branch), so
+/// listing them here would be dead + misleading.
 private let serverRoutedSlashCommands: Set<String> = [
-  "retry", "queue", "q", "steer", "plan", "goal", "moa", "undo", "learn", "compress", "compact",
+  "retry", "queue", "q", "steer", "plan", "goal", "moa", "undo", "learn",
 ]
+
+/// The compress family — the parsed first token (lowercased) that routes to the dedicated
+/// `session.compress` gateway RPC rather than the generic `slash.exec` pipeline. HARDCODED
+/// on purpose: it must NOT depend on the server `commands.catalog`, because an older agent's
+/// catalog mislabels the `/compact` alias (its `canon` self-maps `/compact → /compact`), so a
+/// catalog-derived resolution would send `/compact` back down the broken slash-worker path.
+private let compressCommandNames: Set<String> = ["compress", "compact"]
 
 /// The typed `command.dispatch` directive `type`s the client acts on — the SINGLE source of
 /// truth for both `isDispatchDirective` (the gate) and `runDispatchDirective`'s switch (the
@@ -3301,6 +3350,73 @@ private func executeSlashCommand(
   } catch {
     await send(.slashCommandFailed(message: GatewayError.disconnected.message))
   }
+}
+
+/// Run `/compress` / `/compact` through the DEDICATED `session.compress` gateway RPC — the
+/// desktop's version-independent path (`use-prompt-actions/slash.ts`), sidestepping the
+/// `slash.exec` slash-worker subprocess whose registry can't resolve the `compact` alias on
+/// older agents ("Unknown command: /compact"). A typed argument threads through as the
+/// compression `focus_topic` (the server reads `focus_topic`; omitted when empty for a
+/// byte-minimal request). The RPC rides the standard #17 session-not-found self-heal, exactly
+/// like the slash / prompt paths.
+///
+/// Terminal handling reuses the SLASH pipeline's own actions so the composer-lock,
+/// `runningChanged`, cross-client `thinkingRowID` guard, and post-command server-authoritative
+/// refresh (`session.resume` → context-usage pill + rewritten transcript) all behave
+/// identically: success → `.slashCommandOutput(confirmation)` (`finishSlashExec(refresh:true)`),
+/// failure → `.slashCommandFailed` (`finishSlashExec(refresh:false)`). Never a swallowed `try?`.
+private func executeCompress(
+  focusTopic: String,
+  sessionID: String,
+  storedSessionID: String?,
+  branchSeed: ChatFeature.State.BranchSeed? = nil,
+  profile: String?,
+  gateway: HermesGatewayClient,
+  send: Send<ChatFeature.Action>
+) async {
+  do {
+    let result = try await withSessionHeal(
+      { targetID in
+        var fields: [String: JSONValue] = ["session_id": .string(targetID)]
+        let topic = focusTopic.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !topic.isEmpty { fields["focus_topic"] = .string(topic) }
+        return try await gateway.send("session.compress", .object(fields))
+      },
+      sessionID: sessionID, storedSessionID: storedSessionID,
+      branchSeed: branchSeed, profile: profile, gateway: gateway, send: send
+    )
+    await send(.slashCommandOutput(compressConfirmation(from: result)))
+  } catch let error as GatewayError {
+    await send(.slashCommandFailed(message: error.message))
+  } catch {
+    await send(.slashCommandFailed(message: GatewayError.disconnected.message))
+  }
+}
+
+/// Build the transcript confirmation for a `session.compress` response, preferring the
+/// server's own display text and degrading to a synthesized line so the user always gets an
+/// honest acknowledgement (the response shape varies: a rich `summary`, a lock-held
+/// `message`, a compute-host `host_ack.output`, a bare `removed` count, or nothing). ANSI is
+/// stripped downstream by `appendCommandOutput`.
+private func compressConfirmation(from result: JSONValue) -> String {
+  // The rich summary (headline + token line + note) — the most informative, when present.
+  if let headline = result["summary"]?["headline"]?.stringValue?.nonEmpty {
+    let lines = [headline, result["summary"]?["token_line"]?.stringValue, result["summary"]?["note"]?.stringValue]
+      .compactMap { $0?.nonEmpty }
+    return lines.joined(separator: "\n")
+  }
+  // Lock-held (another compression already running) carries a human-readable `message`.
+  if let message = result["message"]?.stringValue?.nonEmpty { return message }
+  // Compute-host isolated sessions return their acknowledgement text under `host_ack`.
+  if let hostOutput = result["host_ack"]?["output"]?.stringValue?
+    .trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty {
+    return hostOutput
+  }
+  // A plain compressed count, then the honest catch-all confirmation.
+  if let removed = result["removed"]?.intValue, removed > 0 {
+    return "Compressed \(removed) message\(removed == 1 ? "" : "s")."
+  }
+  return "Context compressed."
 }
 
 /// Run a `prompt.submit` with transparent self-heal on "session not found" (#17): replay the

--- a/HermesKit/Sources/HermesKit/Models/CommandCatalog.swift
+++ b/HermesKit/Sources/HermesKit/Models/CommandCatalog.swift
@@ -62,6 +62,34 @@ public struct CommandCatalog: Equatable, Sendable, Decodable {
     return commands.contains { $0.name.lowercased() == key }
   }
 
+  /// Resolve a typed command's FIRST TOKEN to its canonical spelling via the `canonical`
+  /// alias map, leaving the argument (and its separating whitespace) untouched, so a typed
+  /// alias reaches `slash.exec` as its canonical name — `/compact here 5` → `/compress here 5`.
+  /// Matching is case-insensitive on the name (mirroring `resolvesCommand`/the suggestion
+  /// filter). A token that is NOT a known alias — an already-canonical command, a skill route,
+  /// or anything absent from the map — is returned UNCHANGED so raw text is never mangled.
+  ///
+  /// This is applied to the WIRE command only; the user still sees the RAW `/compact` they
+  /// typed in the transcript. Mirrors the desktop/web reference, which resolves through the
+  /// `canon` map before calling `slash.exec`: the gateway's live handler recognizes only
+  /// canonical names (`_LIVE_SESSION_DIRECT_COMMANDS`, `tui_gateway/server.py`), so a raw
+  /// alias falls through to the isolated slash-worker subprocess and reports "Unknown command".
+  public func canonicalizedCommandText(_ text: String) -> String {
+    let body = text.drop(while: { $0 == "/" })
+    let name: Substring
+    let remainder: Substring // includes the leading whitespace before the argument
+    if let space = body.firstIndex(where: \.isWhitespace) {
+      name = body[..<space]
+      remainder = body[space...]
+    } else {
+      name = body
+      remainder = ""
+    }
+    // `canonical` values already carry the leading slash (e.g. "/compress").
+    guard let canon = canonical["/" + name.lowercased()] else { return text }
+    return canon + remainder
+  }
+
   /// Commands with no usable mobile surface. Static and unit-tested; applied at decode.
   /// Two groups, both verified against `tui_gateway/server.py` + `hermes_cli/commands.py`:
   ///

--- a/HermesKit/Sources/HermesKit/Models/StringExtensions.swift
+++ b/HermesKit/Sources/HermesKit/Models/StringExtensions.swift
@@ -10,4 +10,54 @@ extension String {
   var trimmedNonEmpty: String? {
     trimmingCharacters(in: .whitespacesAndNewlines).nonEmpty
   }
+
+  /// This string with ANSI/VT100 escape sequences removed. The agent formats slash-command
+  /// output for a terminal (SGR colors, cursor moves, box-drawing color runs); on mobile
+  /// those render as literal garbage (`[1;31m`, `[0m`, `[38;2;255;215;0m`, …) because the
+  /// introducing ESC byte (`0x1B`) is invisible. Applied to every slash-pipeline string
+  /// before it becomes a `commandOutput` row or is set into the composer (#36 follow-up).
+  ///
+  /// ONLY ESC-introduced sequences are stripped — normal text is left byte-for-byte intact,
+  /// including box-drawing (`+---+`, `|`), the `(^_^)?` mascot, multibyte characters, and a
+  /// literal `[abc]` that has no ESC prefix. Handled: CSI (`ESC [` params `[0-9;:<>=?]*`
+  /// intermediates `[ -/]*` final `[@-~]` — covers SGR `m`, cursor moves), OSC
+  /// (`ESC ] … BEL|ST`), and any other two-byte `ESC <byte>` sequence, plus a lone trailing
+  /// ESC. Pure and platform-agnostic (outside any UIKit guard) so it is unit-tested on macOS.
+  var strippingANSI: String {
+    // Fast path: no ESC byte means no escape sequences — return the original untouched.
+    guard contains("\u{1B}") else { return self }
+
+    let scalars = Array(unicodeScalars)
+    var result = String.UnicodeScalarView()
+    result.reserveCapacity(scalars.count)
+    var i = 0
+    while i < scalars.count {
+      guard scalars[i] == "\u{1B}" else {
+        result.append(scalars[i])
+        i += 1
+        continue
+      }
+      // ESC: consume the whole escape sequence.
+      let next = i + 1 < scalars.count ? scalars[i + 1] : nil
+      switch next {
+      case "["?: // CSI: ESC [ <params> <intermediates> <final>
+        i += 2
+        while i < scalars.count, (0x30...0x3F).contains(scalars[i].value) { i += 1 } // params
+        while i < scalars.count, (0x20...0x2F).contains(scalars[i].value) { i += 1 } // intermediates
+        if i < scalars.count, (0x40...0x7E).contains(scalars[i].value) { i += 1 }    // final byte
+      case "]"?: // OSC: ESC ] ... terminated by BEL (0x07) or ST (ESC \)
+        i += 2
+        while i < scalars.count {
+          if scalars[i] == "\u{07}" { i += 1; break } // BEL
+          if scalars[i] == "\u{1B}", i + 1 < scalars.count, scalars[i + 1] == "\\" { i += 2; break } // ST
+          i += 1
+        }
+      case .some: // any other two-byte ESC sequence (drop ESC + the following byte)
+        i += 2
+      case nil: // a lone trailing ESC
+        i += 1
+      }
+    }
+    return String(result)
+  }
 }

--- a/HermesKit/Tests/HermesKitTests/CommandCatalogTests.swift
+++ b/HermesKit/Tests/HermesKitTests/CommandCatalogTests.swift
@@ -238,6 +238,39 @@ struct CommandCatalogTests {
     #expect(!catalog.resolvesCommand(named: ""))
   }
 
+  // MARK: canonicalizedCommandText (alias → canonical WIRE command, #36 follow-up)
+
+  @Test func canonicalizedCommandTextResolvesAliasToCanonical() throws {
+    let catalog = try decode(fullFixture)
+    // The bare alias becomes its canonical name — the wire command sent to slash.exec.
+    #expect(catalog.canonicalizedCommandText("/compact") == "/compress")
+  }
+
+  @Test func canonicalizedCommandTextPreservesTheArgumentVerbatim() throws {
+    let catalog = try decode(fullFixture)
+    // Only the first token is rewritten; the argument (and its separating whitespace) is
+    // left untouched — including interior/multiline whitespace.
+    #expect(catalog.canonicalizedCommandText("/compact here 5") == "/compress here 5")
+    #expect(catalog.canonicalizedCommandText("/compact focus\ntopic") == "/compress focus\ntopic")
+  }
+
+  @Test func canonicalizedCommandTextLeavesCanonicalAndUnknownUnchanged() throws {
+    let catalog = try decode(fullFixture)
+    // An already-canonical name (self-mapping in `canon`) round-trips unchanged.
+    #expect(catalog.canonicalizedCommandText("/compress here 5") == "/compress here 5")
+    #expect(catalog.canonicalizedCommandText("/model gpt") == "/model gpt")
+    // A token with no alias entry (skill route / unknown) is never mangled.
+    #expect(catalog.canonicalizedCommandText("/research quantum") == "/research quantum")
+    #expect(catalog.canonicalizedCommandText("/totallyunknown foo") == "/totallyunknown foo")
+  }
+
+  @Test func canonicalizedCommandTextIsCaseInsensitiveOnTheName() throws {
+    let catalog = try decode(fullFixture)
+    // The name resolves case-insensitively (matching `resolvesCommand` / the filter); the
+    // canonical spelling comes from the map, the argument keeps its original casing.
+    #expect(catalog.canonicalizedCommandText("/COMPACT Keep This ARG") == "/compress Keep This ARG")
+  }
+
   // MARK: Lenient decoding
 
   @Test func emptyObjectDecodesToEmptyCatalog() throws {

--- a/HermesKit/Tests/HermesKitTests/HermesGatewayClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/HermesGatewayClientTests.swift
@@ -198,8 +198,39 @@ private func requestID(_ frame: String) -> Int? {
     await clock.advance(by: .seconds(75))
     await task.value
     #expect(thrown.value as? GatewayError == .timedOut(method: "slash.exec"))
-    // The long budget is scoped to the slash pipeline — the method list is the contract.
-    #expect(HermesGatewayClient.longRunningMethods == ["slash.exec", "command.dispatch"])
+    // The long budget is scoped to the slash pipeline + the dedicated compress RPC — the
+    // method list is the contract. `session.compress` runs the same unbounded inline LLM
+    // summarisation and MUST get the 120s budget (`/compress`/`/compact` now call it directly).
+    #expect(HermesGatewayClient.longRunningMethods == ["slash.exec", "command.dispatch", "session.compress"])
+  }
+
+  @Test func sessionCompressGetsTheLongPerRequestBudget() async throws {
+    // `/compress`/`/compact` now call the dedicated `session.compress` RPC, whose handler runs
+    // the same UNBOUNDED inline LLM summarisation. Under the 30s default it would time out on
+    // exactly the large sessions worth compressing — so it must ride the 120s long budget.
+    let clock = TestClock()
+    let transport = FakeTransport() // never answers
+    let client = HermesGatewayClient.make(
+      requestTimeout: .seconds(30), longRequestTimeout: .seconds(120), clock: clock
+    ) { _ in transport }
+    let stream = client.connect(url, .token("t"))
+    defer { withExtendedLifetime(stream) {} }
+
+    let thrown = LockIsolated<(any Error)?>(nil)
+    let task = Task {
+      do { _ = try await client.send("session.compress", .object(["session_id": .string("s1")])) }
+      catch { thrown.setValue(error) }
+    }
+    for _ in 0..<20 { await Task.yield() }
+    // Well past the default budget: the compress call must still be waiting.
+    await clock.advance(by: .seconds(45))
+    for _ in 0..<20 { await Task.yield() }
+    #expect(thrown.value == nil)
+
+    // …and it does still time out eventually, at the long budget.
+    await clock.advance(by: .seconds(75))
+    await task.value
+    #expect(thrown.value as? GatewayError == .timedOut(method: "session.compress"))
   }
 
   @Test func normalResponseResolvesAndTimeoutDoesNotFire() async throws {

--- a/HermesKit/Tests/HermesKitTests/SlashCommandChatTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SlashCommandChatTests.swift
@@ -528,21 +528,23 @@ struct SlashCommandChatTests {
   }
 
   @Test func slashAliasIsCanonicalizedForTheWireCommand() async {
-    // BUG (#36 follow-up): typing the ALIAS `/compact` in FULL must reach `slash.exec` as its
-    // CANONICAL name `compress`. The gateway's live handler recognizes only canonical names
-    // (`_LIVE_SESSION_DIRECT_COMMANDS`), so a raw alias falls through to the isolated
-    // slash-worker subprocess and reports "Unknown command: /compact". The user still SEES
-    // the raw `/compact` they typed in the transcript — only the wire command is canonical.
+    // #36 follow-up (still live for NON-compress aliases): typing an ALIAS in FULL must reach
+    // `slash.exec` as its CANONICAL name — the gateway's live handler recognizes only canonical
+    // names (`_LIVE_SESSION_DIRECT_COMMANDS`), so a raw alias would fall through to the isolated
+    // slash-worker subprocess and report "Unknown command". The user still SEES the raw alias
+    // they typed in the transcript — only the wire command is canonical. (`/compress`/`/compact`
+    // no longer exercise this path — they route to the dedicated `session.compress` RPC — so
+    // this uses the generic `/st → /status` alias, proving the retained canonicalization helper.)
     let execParams = LockIsolated<JSONValue?>(nil)
     var initial = ChatFeature.State(connection: conn)
     initial.liveSessionID = "live123"
     initial.storedSessionID = "stored123"
     initial.commandCatalog = CommandCatalog(
-      commands: [SlashCommand(name: "/compress", description: "Compress context", category: "Session", isSkill: false)],
+      commands: [SlashCommand(name: "/status", description: "Show status", category: "Session", isSkill: false)],
       subcommands: [:],
-      canonical: ["/compress": "/compress", "/compact": "/compress"]
+      canonical: ["/status": "/status", "/st": "/status"]
     )
-    initial.composerText = "/compact here 5"
+    initial.composerText = "/st here 5"
     let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
       $0.uuid = .incrementing
       $0.date = .constant(Date(timeIntervalSince1970: 0))
@@ -551,7 +553,7 @@ struct SlashCommandChatTests {
       $0.hermesGateway.send = { @Sendable method, params in
         if method == "slash.exec" {
           execParams.setValue(params)
-          return .object(["output": .string("compressed 20 → 8 messages")])
+          return .object(["output": .string("status: all good")])
         }
         return .object([
           "session_id": .string("live123"), "messages": .array([]), "running": .bool(false),
@@ -564,7 +566,7 @@ struct SlashCommandChatTests {
     await store.send(.composerSubmitted) {
       // The RAW typed alias is echoed as the user row — only the WIRE command is canonical.
       $0.transcript = [
-        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/compact here 5", isComplete: true)),
+        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/st here 5", isComplete: true)),
       ]
       $0.composerText = ""
       $0.isSending = true
@@ -572,8 +574,8 @@ struct SlashCommandChatTests {
     }
     await store.receive(\.slashCommandOutput)
     await store.finish()
-    // The alias was resolved: slash.exec got "compress here 5", NEVER "compact here 5".
-    #expect(execParams.value?["command"]?.stringValue == "compress here 5")
+    // The alias was resolved: slash.exec got "status here 5", NEVER "st here 5".
+    #expect(execParams.value?["command"]?.stringValue == "status here 5")
     #expect(execParams.value?["session_id"]?.stringValue == "live123")
   }
 
@@ -1018,13 +1020,15 @@ struct SlashCommandChatTests {
   }
 
   @Test func serverRoutedCommandFailureSkipsTheDispatchFallback() async {
-    // The gateway routes `_PENDING_INPUT_COMMANDS` (`/undo`, `/retry`, `/compact`, …)
+    // The gateway routes `_PENDING_INPUT_COMMANDS` (`/undo`, `/retry`, `/steer`, …)
     // through `command.dispatch` ITSELF, inside `slash.exec`. An error therefore comes FROM
     // a dispatch that already ran, so re-issuing our own would re-enter the same handler —
-    // a `/compact` that reached "compress failed" has already mutated history and would be
-    // recompressed. Same double-execution class as the transport-failure guard.
+    // a `/retry` that reached its truncate-and-resend has already mutated history and would
+    // run twice. Same double-execution class as the transport-failure guard. (`/compress`/
+    // `/compact` are NOT here: they route to the dedicated `session.compress` RPC and never
+    // reach `slash.exec` — covered by the compress tests.)
     let calls = LockIsolated<[String]>([])
-    for command in ["/undo", "/compact", "/retry"] {
+    for command in ["/undo", "/retry", "/steer"] {
       let store = TestStore(
         initialState: readyStateWithCatalog(composerText: command, extraCommands: [command])
       ) { ChatFeature() } withDependencies: {
@@ -1069,6 +1073,301 @@ struct SlashCommandChatTests {
     await store.receive(\.slashCommandFailed)
     await store.finish()
     #expect(other.value == ["slash.exec", "command.dispatch"])
+  }
+
+  // MARK: session.compress (dedicated RPC — desktop parity, version-independent)
+
+  @Test func compressRoutesToSessionCompressNotSlashExec() async {
+    // The reported bug's fix: `/compress` calls the DEDICATED `session.compress` gateway RPC
+    // — NEVER `slash.exec` (which falls through to an isolated worker on older agents). It
+    // locks/unlocks the composer via the SAME slash terminal path, appends a confirmation
+    // commandOutput row (from the server summary), and runs the server-authoritative refresh
+    // so the transcript + context-usage pill update (compression rewrites history + usage).
+    // NOTE: the shared catalog does NOT contain `/compress` — detection is hardcoded
+    // (`compressCommandNames`), NOT catalog-derived, proving it works even when the catalog
+    // omits or mislabels it.
+    let calls = LockIsolated<[String]>([])
+    let compressParams = LockIsolated<JSONValue?>(nil)
+    let snapshot = ChatSnapshotClient.inMemory()
+    let store = TestStore(
+      initialState: readyStateWithCatalog(composerText: "/compress")
+    ) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = snapshot
+      $0.hermesGateway.send = { @Sendable method, params in
+        calls.withValue { $0.append(method) }
+        switch method {
+        case "session.compress":
+          compressParams.setValue(params)
+          return .object([
+            "status": .string("compressed"),
+            "removed": .number(8),
+            "summary": .object([
+              "headline": .string("Compressed 12 → 4 messages"),
+              "token_line": .string("~40,000 → ~12,000 tokens"),
+              "note": .string("Older turns summarized."),
+              "aborted": .bool(false),
+            ]),
+            "usage": .object(["context_used": .number(12000), "context_max": .number(200_000)]),
+          ])
+        case "session.resume":
+          return .object([
+            "session_id": .string("live123"),
+            "messages": .array([
+              .object(["id": .number(1), "role": .string("user"), "text": .string("compressed history")]),
+            ]),
+            "running": .bool(false),
+            "info": .object([
+              "model": .string("claude-opus-4-8"),
+              "usage": .object(["context_used": .number(12000), "context_max": .number(200_000)]),
+            ]),
+          ])
+        default:
+          return .object([:])
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted) {
+      $0.transcript = [
+        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/compress", isComplete: true)),
+      ]
+      $0.composerText = ""
+      $0.isSending = true
+      $0.slashExecInFlight = true
+    }
+    await store.receive(\.slashCommandOutput) {
+      $0.transcript.append(ChatRow(
+        id: self.uuid(1),
+        kind: .commandOutput(text: "Compressed 12 → 4 messages\n~40,000 → ~12,000 tokens\nOlder turns summarized.")
+      ))
+      $0.isSending = false
+      $0.slashExecInFlight = false
+    }
+    await store.receive({ action in
+      guard case let .delegate(.runningChanged(sessionID, running)) = action else { return false }
+      return sessionID == "stored123" && running == false
+    })
+    await store.receive(\.slashHistoryRefreshed) {
+      $0.usage = Usage(contextUsed: 12000, contextMax: 200_000)
+    }
+    await store.finish()
+
+    // Exactly the dedicated RPC + the post-command refresh — NEVER slash.exec/command.dispatch.
+    #expect(calls.value == ["session.compress", "session.resume"])
+    #expect(compressParams.value?["session_id"]?.stringValue == "live123")
+    // No focus topic typed → the param is omitted (byte-minimal request).
+    #expect(compressParams.value?["focus_topic"] == nil)
+    // Server-authoritative: the transcript is the server's post-compress history with the
+    // ephemeral confirmation carried across the wholesale replace.
+    #expect(store.state.transcript.map(\.kind) == [
+      .message(role: .user, text: "compressed history", isComplete: true),
+      .commandOutput(text: "Compressed 12 → 4 messages\n~40,000 → ~12,000 tokens\nOlder turns summarized."),
+    ])
+    #expect(store.state.errorBanner == nil)
+    // An exec-style command sets NO turn anchor (a hydrate mid-command must not resurrect a
+    // phantom elapsed timer).
+    #expect(snapshot.turnAnchor("stored123") == nil)
+  }
+
+  @Test func compactAliasAlsoRoutesToSessionCompress() async {
+    // The ACTUAL reported bug: the ALIAS `/compact` must ALSO reach `session.compress`, never
+    // `slash.exec`. This holds even with an OLDER agent's MISLABELING catalog whose `canon`
+    // self-maps `/compact → /compact` (so client-side canonicalization is a no-op) — detection
+    // is by hardcoded canonical intent, not the catalog. The RAW `/compact` is echoed as the
+    // user row.
+    let calls = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.storedSessionID = "stored123"
+    // The buggy old-agent catalog: alias self-maps instead of resolving to /compress.
+    initial.commandCatalog = CommandCatalog(
+      commands: [SlashCommand(name: "/compress", description: "Compress context", category: "Session", isSkill: false)],
+      subcommands: [:],
+      canonical: ["/compress": "/compress", "/compact": "/compact"]
+    )
+    initial.composerText = "/compact"
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, _ in
+        calls.withValue { $0.append(method) }
+        switch method {
+        case "session.compress":
+          return .object(["status": .string("compressed"), "removed": .number(3)])
+        case "session.resume":
+          return .object([
+            "session_id": .string("live123"), "messages": .array([]), "running": .bool(false),
+            "info": .object(["usage": .object(["context_used": .number(1), "context_max": .number(200_000)])]),
+          ])
+        default:
+          return .object([:])
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted) {
+      // The RAW typed alias is echoed as the user row.
+      $0.transcript = [
+        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/compact", isComplete: true)),
+      ]
+      $0.composerText = ""
+      $0.isSending = true
+      $0.slashExecInFlight = true
+    }
+    await store.receive(\.slashCommandOutput) {
+      $0.transcript.append(ChatRow(id: self.uuid(1), kind: .commandOutput(text: "Compressed 3 messages.")))
+      $0.isSending = false
+      $0.slashExecInFlight = false
+    }
+    await store.receive({ action in
+      guard case .delegate(.runningChanged) = action else { return false }
+      return true
+    })
+    await store.receive(\.slashHistoryRefreshed)
+    await store.finish()
+
+    // `/compact` reached session.compress — NEVER slash.exec / command.dispatch.
+    #expect(calls.value == ["session.compress", "session.resume"])
+    #expect(store.state.errorBanner == nil)
+  }
+
+  @Test func compressThreadsFocusTopicAndSynthesizesConfirmation() async {
+    // A typed argument becomes the compression `focus_topic`, and when the server returns no
+    // display text (no summary / message / host_ack / removed count) the confirmation is
+    // synthesized to a sensible "Context compressed." so the user always gets feedback.
+    let compressParams = LockIsolated<JSONValue?>(nil)
+    let store = TestStore(
+      initialState: readyStateWithCatalog(composerText: "/compress just the auth flow")
+    ) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        switch method {
+        case "session.compress":
+          compressParams.setValue(params)
+          return .object(["status": .string("compressed")]) // no display text at all
+        case "session.resume":
+          return .object([
+            "session_id": .string("live123"), "messages": .array([]), "running": .bool(false),
+            "info": .object(["usage": .object(["context_used": .number(1), "context_max": .number(200_000)])]),
+          ])
+        default:
+          return .object([:])
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted)
+    await store.receive(\.slashCommandOutput) {
+      $0.isSending = false
+    }
+    await store.finish()
+    #expect(compressParams.value?["focus_topic"]?.stringValue == "just the auth flow")
+    #expect(store.state.transcript.last?.kind == .commandOutput(text: "Context compressed."))
+  }
+
+  @Test func compressFailureSurfacesBannerAndUnlocks() async {
+    // A `session.compress` failure surfaces `.slashCommandFailed` (banner + unlocked composer)
+    // — never a swallowed `try?` — and runs NO history refresh (a failure lands no change).
+    let calls = LockIsolated<[String]>([])
+    let store = TestStore(
+      initialState: readyStateWithCatalog(composerText: "/compress")
+    ) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, _ in
+        calls.withValue { $0.append(method) }
+        throw GatewayError.server("compress boom")
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted) {
+      $0.transcript = [
+        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/compress", isComplete: true)),
+      ]
+      $0.composerText = ""
+      $0.isSending = true
+      $0.slashExecInFlight = true
+    }
+    await store.receive(\.slashCommandFailed) {
+      $0.errorBanner = "Command failed: compress boom"
+      $0.isSending = false
+      $0.slashExecInFlight = false
+    }
+    await store.receive({ action in
+      guard case let .delegate(.runningChanged(sessionID, running)) = action else { return false }
+      return sessionID == "stored123" && running == false
+    })
+    await store.finish()
+    // Only the compress RPC ran — no dispatch fallback, no refresh.
+    #expect(calls.value == ["session.compress"])
+    #expect(store.state.transcript.map(\.kind) == [
+      .message(role: .user, text: "/compress", isComplete: true),
+    ])
+  }
+
+  @Test func compressSelfHealsOnSessionNotFound() async {
+    // The compress RPC rides the standard #17 self-heal: a stale live id answers "session not
+    // found" → re-resume for a fresh id, replay session.compress ONCE against it, confirmation
+    // lands with no banner. Mirrors the slash-exec heal test shape.
+    let calls = LockIsolated<[(method: String, sid: String?)]>([])
+    var initial = readyStateWithCatalog(composerText: "/compress")
+    initial.liveSessionID = "stale-live"
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        let sid = params["session_id"]?.stringValue
+        calls.withValue { $0.append((method, sid)) }
+        switch method {
+        case "session.compress":
+          if sid == "stale-live" { throw GatewayError.server("session not found") }
+          return .object(["status": .string("compressed"), "removed": .number(2)])
+        case "session.resume":
+          // Serves both the #17 heal and the post-command refresh.
+          return .object([
+            "session_id": .string("fresh-live"),
+            "stored_session_id": .string("stored123"),
+            "messages": .array([]),
+            "running": .bool(false),
+            "info": .object(["usage": .object(["context_used": .number(1), "context_max": .number(200_000)])]),
+          ])
+        default:
+          return .object([:])
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted)
+    await store.receive(\.liveSessionIDRefreshed) {
+      $0.liveSessionID = "fresh-live"
+    }
+    await store.receive(\.slashCommandOutput) {
+      $0.isSending = false
+    }
+    await store.finish()
+
+    // compress (stale) → heal-resume → single replay (fresh id) → post-command refresh.
+    #expect(calls.value.map(\.method) == ["session.compress", "session.resume", "session.compress", "session.resume"])
+    #expect(calls.value[2].sid == "fresh-live")
+    #expect(store.state.errorBanner == nil)
+    #expect(store.state.transcript.last?.kind == .commandOutput(text: "Compressed 2 messages."))
   }
 
   @Test func hydrateMidExecKeepsTheComposerLocked() async {

--- a/HermesKit/Tests/HermesKitTests/SlashCommandChatTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SlashCommandChatTests.swift
@@ -527,6 +527,85 @@ struct SlashCommandChatTests {
     #expect(snapshot.turnAnchor("stored123") == nil)
   }
 
+  @Test func slashAliasIsCanonicalizedForTheWireCommand() async {
+    // BUG (#36 follow-up): typing the ALIAS `/compact` in FULL must reach `slash.exec` as its
+    // CANONICAL name `compress`. The gateway's live handler recognizes only canonical names
+    // (`_LIVE_SESSION_DIRECT_COMMANDS`), so a raw alias falls through to the isolated
+    // slash-worker subprocess and reports "Unknown command: /compact". The user still SEES
+    // the raw `/compact` they typed in the transcript — only the wire command is canonical.
+    let execParams = LockIsolated<JSONValue?>(nil)
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.storedSessionID = "stored123"
+    initial.commandCatalog = CommandCatalog(
+      commands: [SlashCommand(name: "/compress", description: "Compress context", category: "Session", isSkill: false)],
+      subcommands: [:],
+      canonical: ["/compress": "/compress", "/compact": "/compress"]
+    )
+    initial.composerText = "/compact here 5"
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        if method == "slash.exec" {
+          execParams.setValue(params)
+          return .object(["output": .string("compressed 20 → 8 messages")])
+        }
+        return .object([
+          "session_id": .string("live123"), "messages": .array([]), "running": .bool(false),
+          "info": .object(["usage": .object(["context_used": .number(1), "context_max": .number(200_000)])]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted) {
+      // The RAW typed alias is echoed as the user row — only the WIRE command is canonical.
+      $0.transcript = [
+        ChatRow(id: self.uuid(0), kind: .message(role: .user, text: "/compact here 5", isComplete: true)),
+      ]
+      $0.composerText = ""
+      $0.isSending = true
+      $0.slashExecInFlight = true
+    }
+    await store.receive(\.slashCommandOutput)
+    await store.finish()
+    // The alias was resolved: slash.exec got "compress here 5", NEVER "compact here 5".
+    #expect(execParams.value?["command"]?.stringValue == "compress here 5")
+    #expect(execParams.value?["session_id"]?.stringValue == "live123")
+  }
+
+  @Test func slashExecOutputIsStrippedOfANSIEscapes() async {
+    // BUG (#36 follow-up): the agent formats slash output for a terminal (SGR colors,
+    // box-drawing color runs). On mobile the ESC byte is invisible, so the sequences render
+    // as literal garbage (`[1;31m`, `[0m`, `[38;2;255;215;0m`). The `commandOutput` row must
+    // be clean — the mascot and box-drawing chrome are kept, only ESC sequences removed.
+    let esc = "\u{1B}"
+    let ansi = "\(esc)[1;31mUnknown command: /foo\(esc)[0m\n\(esc)[38;2;255;215;0m(^_^)?\(esc)[0m +---+"
+    let store = TestStore(initialState: readyStateWithCatalog()) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, _ in
+        if method == "slash.exec" { return .object(["output": .string(ansi)]) }
+        return .object([
+          "session_id": .string("live123"), "messages": .array([]), "running": .bool(false),
+          "info": .object(["usage": .object(["context_used": .number(1), "context_max": .number(200_000)])]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted)
+    await store.receive(\.slashCommandOutput)
+    await store.finish()
+    // The ephemeral row (carried across the post-command refresh) is clean text.
+    #expect(store.state.transcript.last?.kind == .commandOutput(text: "Unknown command: /foo\n(^_^)? +---+"))
+  }
+
   @Test func slashExecWarningAndEmptyOutputDegradeGracefully() async {
     // Web-reference parity: a `warning` is prefixed above the body, and an empty/missing
     // `output` degrades to "/name: no output" rather than an empty row.

--- a/HermesKit/Tests/HermesKitTests/StringANSIStrippingTests.swift
+++ b/HermesKit/Tests/HermesKitTests/StringANSIStrippingTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import HermesKit
+
+/// `String.strippingANSI` (#36 follow-up): the agent formats slash-command output for a
+/// terminal (SGR colors, cursor moves, box-drawing color runs); on mobile the introducing
+/// ESC byte (0x1B) is invisible, so the sequences render as literal garbage (`[1;31m`,
+/// `[0m`, `[38;2;255;215;0m`). Only ESC-introduced sequences are removed — normal text,
+/// box-drawing, the mascot, and a literal `[abc]` with no ESC are preserved byte-for-byte.
+struct StringANSIStrippingTests {
+  /// ESC (0x1B) is invisible in source; spell it out for readable fixtures.
+  private let esc = "\u{1B}"
+
+  @Test func removesSGRColorCodes() {
+    #expect("\(esc)[1;31mUnknown command: /foo\(esc)[0m".strippingANSI == "Unknown command: /foo")
+    #expect("\(esc)[2;3mitalic dim\(esc)[0m".strippingANSI == "italic dim")
+  }
+
+  @Test func removes24BitTrueColorCodes() {
+    // 24-bit foreground: ESC[38;2;R;G;Bm (gold), then reset.
+    #expect("\(esc)[1;38;2;255;215;0mgold\(esc)[0m".strippingANSI == "gold")
+  }
+
+  @Test func removesLoneResetCode() {
+    #expect("done\(esc)[0m".strippingANSI == "done")
+  }
+
+  @Test func plainTextIsUnchanged() {
+    #expect("just plain text".strippingANSI == "just plain text")
+    #expect("".strippingANSI == "")
+    // No ESC anywhere → returned verbatim via the fast path.
+    #expect("no escapes here 123 !@#".strippingANSI == "no escapes here 123 !@#")
+  }
+
+  @Test func boxDrawingAndMascotArePreserved() {
+    // The mascot and box-drawing chrome must survive — they are not ESC-introduced.
+    #expect("(^_^)?".strippingANSI == "(^_^)?")
+    #expect("+---+\n| x |\n+---+".strippingANSI == "+---+\n| x |\n+---+")
+    // Multibyte characters are untouched.
+    #expect("↶ Undid 1 turn — café ☕".strippingANSI == "↶ Undid 1 turn — café ☕")
+  }
+
+  @Test func literalBracketTextWithoutESCIsPreserved() {
+    // A literal `[abc]` / `[1;31m`-looking run with NO ESC prefix is ordinary text.
+    #expect("[abc]".strippingANSI == "[abc]")
+    #expect("array[1;31m] index".strippingANSI == "array[1;31m] index")
+  }
+
+  @Test func escPrefixedSequenceLookingLikeLiteralIsStripped() {
+    // The visible `[1;31m` tail preceded by a REAL (invisible) ESC IS an escape sequence.
+    #expect("\(esc)[1;31m".strippingANSI == "")
+    #expect("a\(esc)[1;31mb".strippingANSI == "ab")
+  }
+
+  @Test func stripsMixedColorRunsKeepingContent() {
+    let input = "\(esc)[1;31mUnknown command: /foo\(esc)[0m\n\(esc)[38;2;255;215;0m(^_^)?\(esc)[0m +---+"
+    #expect(input.strippingANSI == "Unknown command: /foo\n(^_^)? +---+")
+  }
+
+  @Test func stripsCursorMovementAndOtherCSIFinals() {
+    // CSI sequences with non-`m` finals (cursor moves, clear) are removed too.
+    #expect("\(esc)[2J\(esc)[Hcleared".strippingANSI == "cleared")
+    #expect("x\(esc)[3Dy".strippingANSI == "xy")
+  }
+
+  @Test func stripsOSCSequences() {
+    // OSC (set window title): ESC ] ... BEL. And ST-terminated (ESC \) form.
+    #expect("\(esc)]0;window title\u{07}body".strippingANSI == "body")
+    #expect("\(esc)]8;;https://example.com\(esc)\\link".strippingANSI == "link")
+  }
+
+  @Test func stripsOtherTwoByteAndLoneTrailingESC() {
+    // A two-byte Fe escape (ESC + a byte) is dropped; a lone trailing ESC is dropped.
+    #expect("a\(esc)Mb".strippingANSI == "ab")
+    #expect("tail\(esc)".strippingANSI == "tail")
+  }
+}

--- a/Project.swift
+++ b/Project.swift
@@ -77,7 +77,7 @@ let project = Project(
           "DEVELOPMENT_TEAM": .string(developmentTeam),
           "CODE_SIGN_STYLE": "Automatic",
           "MARKETING_VERSION": "1.0",
-          "CURRENT_PROJECT_VERSION": "48",
+          "CURRENT_PROJECT_VERSION": "51",
           // Production default (App Store / external TestFlight) — the orange "AppIcon".
           // Debug builds override to the blue "AppIconDev" below. INTERNAL TestFlight
           // archives the Release config but overrides the icon on the xcodebuild command


### PR DESCRIPTION
Follow-up fixes to the slash-command feature (#36), from live TestFlight testing.

## Fixes
- **`/compress` and `/compact` now work on all agent versions.** They previously routed through the generic `slash.exec` pipeline; on older hermes-agent builds the catalog doesn't map the `/compact` alias to `/compress`, so the raw alias hit an isolated CLI worker that reported "Unknown command: /compact". Now both call the dedicated **`session.compress`** gateway RPC directly (desktop parity), bypassing the worker entirely — version-independent. Proven by a test using a deliberately-mislabeling old-agent catalog.
- **ANSI escape codes stripped from slash output.** The agent formats command output for a terminal (color/style SGR codes, cursor moves, OSC); these rendered as literal `[1;31m` / `[0m` garbage. A pure `strippingANSI` helper cleans all slash output/notice/prefill text at a single chokepoint. Box-drawing, mascots, and normal text are preserved; regular assistant messages are untouched.
- **Alias canonicalization** kept as a defensive layer (resolves aliases via the catalog `canon` map before sending), now that compress/compact no longer depend on it.
- `session.compress` added to the client's 120s long-running RPC budget.
- Build number set to 51 (matches the TestFlight build).

## Testing
945 HermesKit tests pass; snapshot suite passes. New coverage: `/compress` and the `/compact` alias both route to `session.compress` (not `slash.exec`), focus-topic threading, failure/self-heal paths, ANSI stripping (unit + reducer), and a regression guard that non-compress commands still use `slash.exec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
