### PR TITLE
fix: keep model and reasoning selections after reconnect

### DIFF
--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -1767,12 +1767,20 @@ public struct ChatFeature {
         // Blocked mid-turn (server returns 4009); the picker disables selection too.
         guard !state.isSending, let sessionID = state.liveSessionID else { return .none }
         state.model = model // optimistic; reconciled by the next session.info
-        return configSet(key: "model", value: model, sessionID: sessionID)
+        return configSet(
+          key: "model", value: model, sessionID: sessionID,
+          storedSessionID: state.storedSessionID, branchSeed: state.branchSeed,
+          profile: state.scopedProfile
+        )
 
       case let .reasoningSelected(effort):
         guard !state.isSending, let sessionID = state.liveSessionID else { return .none }
         state.reasoningEffort = effort
-        return configSet(key: "reasoning", value: effort, sessionID: sessionID)
+        return configSet(
+          key: "reasoning", value: effort, sessionID: sessionID,
+          storedSessionID: state.storedSessionID, branchSeed: state.branchSeed,
+          profile: state.scopedProfile
+        )
 
       case .modelPickerDismissed:
         state.modelPicker = nil
@@ -2916,15 +2924,25 @@ public struct ChatFeature {
     }
   }
 
-  /// Change a session setting (model / reasoning) over the gateway. Fire-and-forget —
-  /// the authoritative value comes back on the next `session.info`.
-  private func configSet(key: String, value: String, sessionID: String) -> Effect<Action> {
-    .run { [gateway] _ in
-      _ = try? await gateway.send("config.set", .object([
-        "session_id": .string(sessionID),
-        "key": .string(key),
-        "value": .string(value),
-      ]))
+  /// Change a session setting (model / reasoning) over the gateway. If iOS resumed with a
+  /// reaped live id, refresh it and replay once rather than letting the optimistic picker value
+  /// snap back when the next authoritative `session.info` arrives.
+  private func configSet(
+    key: String, value: String, sessionID: String,
+    storedSessionID: String?, branchSeed: State.BranchSeed?, profile: String?
+  ) -> Effect<Action> {
+    .run { [gateway] send in
+      func setConfig(_ targetID: String) async throws {
+        _ = try await gateway.send("config.set", .object([
+          "session_id": .string(targetID),
+          "key": .string(key),
+          "value": .string(value),
+        ]))
+      }
+      _ = try? await withSessionHeal(
+        setConfig, sessionID: sessionID, storedSessionID: storedSessionID,
+        branchSeed: branchSeed, profile: profile, gateway: gateway, send: send
+      )
     }
   }
 

--- a/HermesKit/Tests/HermesKitTests/SelfHealTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SelfHealTests.swift
@@ -35,6 +35,40 @@ struct SelfHealTests {
     ])
   }
 
+  // MARK: runtime config self-heal
+
+  @Test func reasoningSelectionSelfHealsOnSessionNotFoundThenSucceeds() async {
+    let calls = LockIsolated<[(method: String, sessionID: String?)]>([])
+    let store = TestStore(initialState: healableState()) { ChatFeature() } withDependencies: {
+      $0.hermesGateway.send = { @Sendable method, params in
+        let sid = params["session_id"]?.stringValue
+        calls.withValue { $0.append((method, sid)) }
+        switch method {
+        case "config.set":
+          if sid == "stale-live" { throw GatewayError.server("session not found") }
+          return .object(["key": .string("reasoning"), "value": .string("xhigh")])
+        case "session.resume":
+          return self.resumePayload(liveID: "fresh-live")
+        default:
+          return .object([:])
+        }
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.reasoningSelected("xhigh")) {
+      $0.reasoningEffort = "xhigh"
+    }
+    await store.receive(\.liveSessionIDRefreshed) {
+      $0.liveSessionID = "fresh-live"
+    }
+    await store.finish()
+
+    #expect(calls.value.map(\.method) == ["config.set", "session.resume", "config.set"])
+    #expect(calls.value.last?.sessionID == "fresh-live")
+    #expect(store.state.reasoningEffort == "xhigh")
+  }
+
   // MARK: prompt.submit self-heal
 
   @Test func promptSubmitSelfHealsOnSessionNotFoundThenSucceeds() async {


### PR DESCRIPTION
## Summary
- Self-heal stale live session IDs before replaying Companion model/reasoning changes.
- Preserve the optimistic reasoning selection instead of snapping back to the server default.
- Cover the stale-session reasoning path with a regression test.

## Root cause
The picker sent `config.set` as fire-and-forget using the cached live session ID. After iOS backgrounding or reconnect, that ID could be reaped. The RPC failed silently, then the next authoritative `session.info` restored the default medium effort.

## Test plan
- RED: New regression test failed with only one `config.set` call and no fresh session.
- GREEN: Targeted self-heal test passes.
- Full HermesKit suite: 946 tests in 56 suites pass.
