### PR TITLE
fix: prevent duplicate sends and queue active-turn prompts

### DIFF
--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -2473,14 +2473,26 @@ public struct ChatFeature {
     // so the next `message.delta` mutates it in place under the same id.
     if let inflight = response.inflight {
       if let user = inflight.user?.nonEmpty {
-        let userKind = ChatRow.Kind.message(role: .user, text: user, isComplete: true)
-        state.transcript.append(ChatRow(
-          id: ChatRow.deterministicID(
-            sequenceIndex: state.transcript.count, role: userKind.role,
-            kindDiscriminator: userKind.discriminator
-          ),
-          kind: userKind
-        ))
+        // Some backend versions include the active turn's submitted prompt in BOTH the
+        // authoritative message history and `inflight.user`. Re-appending it here produces
+        // two adjacent user bubbles after a foreground/reconnect hydrate. Only seed the
+        // in-flight user when the rebuilt history does not already end with that exact row.
+        let historyAlreadyEndsWithUser = state.transcript.last.map { row in
+          if case let .message(role, text, _) = row.kind {
+            return role == .user && text == user
+          }
+          return false
+        } ?? false
+        if !historyAlreadyEndsWithUser {
+          let userKind = ChatRow.Kind.message(role: .user, text: user, isComplete: true)
+          state.transcript.append(ChatRow(
+            id: ChatRow.deterministicID(
+              sequenceIndex: state.transcript.count, role: userKind.role,
+              kindDiscriminator: userKind.discriminator
+            ),
+            kind: userKind
+          ))
+        }
       }
       // Seed the streaming row eagerly when the turn is still streaming so the next
       // `message.delta` reuses it (avoids a duplicate from the lazy first-delta path).

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -36,6 +36,12 @@ public struct ChatFeature {
     /// replace (hydrate). The view renders `visibleRows`, never `transcript` directly.
     public var windowStart: Int
     public var composerText: String
+    /// Messages composed while a turn is running. Held client-side and submitted FIFO
+    /// after each `message.complete`, matching Hermes Desktop/TUI queue semantics.
+    public var queuedPrompts: [QueuedPrompt]
+    /// Queue head currently moving through the existing submit/upload pipeline. Kept until
+    /// the server acknowledges it so failures can restore reliable FIFO delivery.
+    public var activeQueuedPrompt: QueuedPrompt?
     public var status: Status
     public var errorBanner: String?
     public var isSending: Bool
@@ -118,6 +124,18 @@ public struct ChatFeature {
     /// a second tap on the branch button is a no-op until the RPC resolves. Public so the
     /// view can dim the affordance while it runs.
     public var isBranching: Bool
+
+    public struct QueuedPrompt: Equatable, Identifiable, Sendable {
+      public let id: UUID
+      public var text: String
+      public var attachments: [ComposerAttachment]
+
+      public init(id: UUID, text: String, attachments: [ComposerAttachment]) {
+        self.id = id
+        self.text = text
+        self.attachments = attachments
+      }
+    }
 
     /// Whether the branch affordance is enabled (#34): the session must have a PERSISTED
     /// id (`parent_session_id` has to match a REST list row id for the branch to nest —
@@ -316,6 +334,8 @@ public struct ChatFeature {
       self.title = title
       self.transcript = transcript
       self.composerText = composerText
+      self.queuedPrompts = []
+      self.activeQueuedPrompt = nil
       self.status = status
       self.errorBanner = nil
       self.isSending = false
@@ -395,10 +415,12 @@ public struct ChatFeature {
       return transcript.elements[start..<count]
     }
 
+    public var hasComposerPayload: Bool {
+      !composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachments.isEmpty
+    }
+
     public var canSend: Bool {
-      let hasContent = !composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        || !attachments.isEmpty
-      return hasContent
+      hasComposerPayload
         // `liveSessionID` is `nil` both before the first successful attach/hydrate AND
         // for the whole duration of a branch reap-recovery probe/replay (2026-07-24
         // review, finding 1) — `.activateResult(.failure)` nils it the instant a
@@ -425,6 +447,13 @@ public struct ChatFeature {
         // to open the replacement chat, and a just-submitted turn would be silently lost
         // (its socket/effects cancelled with no server response ever observed).
         && !isBranching
+    }
+
+    /// A real turn can accept additional client-side work without interrupting it.
+    /// Slash execution and blocking interactions remain exclusive operations.
+    public var canQueue: Bool {
+      hasComposerPayload && isSending && liveSessionID != nil && pendingInteraction == nil
+        && !slashExecInFlight && !isBranching
     }
 
     /// Rename is only meaningful once we have a live session id (otherwise `confirmRename`
@@ -511,6 +540,9 @@ public struct ChatFeature {
     case activateResult(Result<ActivateResponse, GatewayError>)
     case usageResponse(Usage)
     case composerSubmitted
+    case queuedPromptDrainRequested
+    case queuedPromptAccepted(id: UUID)
+    case removeQueuedPrompt(id: UUID)
     case promptSubmitFailed(message: String)
     /// A self-heal re-resume/recreate landed a fresh live session id for an outbound RPC that
     /// failed with "session not found" (#17). Apply it WITHOUT a wholesale transcript rebuild
@@ -833,7 +865,9 @@ public struct ChatFeature {
         return .none
 
       case let .activateResult(.success(response)):
-        return applyActivate(response, into: &state)
+        let effect = applyActivate(response, into: &state)
+        guard !state.isSending, !state.queuedPrompts.isEmpty else { return effect }
+        return .merge(effect, .send(.queuedPromptDrainRequested))
 
       case let .activateResult(.failure(error)):
         // Structural fix (2026-07-24 review) — see the `hasReplayedBranchSeed`/probe doc
@@ -872,7 +906,9 @@ public struct ChatFeature {
         state.attachLiveSessionID = nil
         state.branchSeed = nil
         state.hasReplayedBranchSeed = false
-        return applyActivate(response, into: &state)
+        let effect = applyActivate(response, into: &state)
+        guard !state.isSending, !state.queuedPrompts.isEmpty else { return effect }
+        return .merge(effect, .send(.queuedPromptDrainRequested))
 
       case let .branchResumeProbeResult(.failure(error)):
         // Structural fix (2026-07-24 review): there is no budget to refund here (see the
@@ -963,6 +999,38 @@ public struct ChatFeature {
         return hydrate(sessionID: sessionID, profile: state.scopedProfile)
 
       case .composerSubmitted:
+        // If an older queued item is waiting and the user has already drafted another one,
+        // preserve FIFO: append the new draft to the tail, then drain the original head.
+        if !state.isSending, state.activeQueuedPrompt == nil,
+           !state.queuedPrompts.isEmpty, state.hasComposerPayload {
+          let text = state.composerText.trimmingCharacters(in: .whitespacesAndNewlines)
+          let attachments = state.attachments.map { attachment in
+            var copy = attachment
+            copy.uploadState = .pending
+            return copy
+          }
+          state.queuedPrompts.append(.init(id: uuid(), text: text, attachments: attachments))
+          state.composerText = ""
+          state.attachments = []
+          return .send(.queuedPromptDrainRequested)
+        }
+
+        // Busy input queues instead of issuing a second prompt.submit. Keep attachments with
+        // their message, reset transient upload state, and clear the live composer at once.
+        if state.isSending {
+          guard state.canQueue else { return .none }
+          let text = state.composerText.trimmingCharacters(in: .whitespacesAndNewlines)
+          let attachments = state.attachments.map { attachment in
+            var copy = attachment
+            copy.uploadState = .pending
+            return copy
+          }
+          state.queuedPrompts.append(.init(id: uuid(), text: text, attachments: attachments))
+          state.composerText = ""
+          state.attachments = []
+          state.errorBanner = nil
+          return .none
+        }
         guard state.canSend, let sessionID = state.liveSessionID else { return .none }
         // Trim stray leading/trailing whitespace/newlines (soft-wrap, dictation, accidental
         // returns) before submitting; interior formatting is preserved (#31). `canSend`
@@ -1151,10 +1219,12 @@ public struct ChatFeature {
         let stored = state.attachLiveSessionID == nil ? state.storedSessionID : nil
         let seed = state.branchSeed
         let profile = state.scopedProfile
+        let queuedPromptID = state.activeQueuedPrompt?.id
         return .merge(anchor, .run { [gateway] send in
           await submitPrompt(
             sessionID: sessionID, storedSessionID: stored, branchSeed: seed,
-            profile: profile, gateway: gateway, send: send
+            profile: profile, gateway: gateway, send: send,
+            queuedPromptID: queuedPromptID
           ) { healedID in
             _ = try await gateway.send("prompt.submit", .object([
               "session_id": .string(healedID), "text": .string(text),
@@ -1162,9 +1232,37 @@ public struct ChatFeature {
           }
         })
 
+      case .queuedPromptDrainRequested:
+        // Do not overwrite a draft started while the previous turn was finishing. The queue
+        // remains visible; once the composer is clear the next completion/drain sends FIFO.
+        guard !state.isSending, state.pendingInteraction == nil,
+              state.activeQueuedPrompt == nil,
+              state.composerText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              state.attachments.isEmpty, !state.queuedPrompts.isEmpty
+        else { return .none }
+        let next = state.queuedPrompts.removeFirst()
+        state.activeQueuedPrompt = next
+        state.composerText = next.text
+        state.attachments = next.attachments
+        return .send(.composerSubmitted)
+
+      case let .queuedPromptAccepted(id):
+        if state.activeQueuedPrompt?.id == id { state.activeQueuedPrompt = nil }
+        return .none
+
+      case let .removeQueuedPrompt(id):
+        state.queuedPrompts.removeAll { $0.id == id }
+        return .none
+
       case let .promptSubmitFailed(message):
         state.errorBanner = "Prompt failed: \(message)"
         state.isSending = false
+        // A queued head is not consumed until prompt.submit acknowledges it. Put a failed
+        // head back at the front so retry/removal preserves FIFO and never loses the text.
+        if let active = state.activeQueuedPrompt {
+          state.queuedPrompts.insert(active, at: 0)
+          state.activeQueuedPrompt = nil
+        }
         // The anchor was written on submit; a failed submit never starts a turn (no
         // `message.start`/`complete` to clear it), so clear it here. This keeps every
         // `setTurnAnchor` paired with a clear, so anchors can't accumulate for sessions that
@@ -1611,6 +1709,7 @@ public struct ChatFeature {
         maintainWindowAfterStreaming(wasAtBottomWindow: wasAtBottomWindow, into: &state)
         state.composerText = ""
         state.attachments = []
+        state.activeQueuedPrompt = nil
         return .none
 
       case let .attachmentUploadFailed(message):
@@ -1668,6 +1767,7 @@ public struct ChatFeature {
         // and a REAL turn now owns `isSending` (it stays locked, driven by the turn's own
         // lifecycle). Only the mid-exec hydrate guard is released — nothing else changes.
         state.slashExecInFlight = false
+        state.activeQueuedPrompt = nil
         return .none
 
       case let .slashCommandPrefill(message, notice):
@@ -1930,8 +2030,12 @@ public struct ChatFeature {
       // finished chat isn't stuck behind a phantom card locking the composer.
       clearStaleApproval(into: &state)
       // Turn ended — drop the anchor so a later hydrate doesn't resurrect a phantom timer,
-      // and tell the list to clear this session's working glow immediately.
-      return .merge(.cancel(id: CancelID.thinkingTimer), clearTurnAnchor(state), runningChanged(false, state))
+      // tell the list to clear this session's working glow, then auto-drain one queued prompt.
+      let drain: Effect<Action> = state.queuedPrompts.isEmpty ? .none : .send(.queuedPromptDrainRequested)
+      return .merge(
+        .cancel(id: CancelID.thinkingTimer), clearTurnAnchor(state),
+        runningChanged(false, state), drain
+      )
 
     case let .thinkingDelta(text):
       appendToThinking(text, into: &state)
@@ -2822,12 +2926,19 @@ public struct ChatFeature {
   /// hydrate (output/prefill land history changes; a failure passes `refresh: false`).
   private func finishSlashExec(refresh: Bool, into state: inout State) -> Effect<Action> {
     state.slashExecInFlight = false
+    state.activeQueuedPrompt = nil
     guard state.thinkingRowID == nil else { return .none }
     state.isSending = false
-    guard refresh, let sessionID = state.liveSessionID else { return runningChanged(false, state) }
+    let drain: Effect<Action> = state.queuedPrompts.isEmpty
+      ? .none
+      : .send(.queuedPromptDrainRequested)
+    guard refresh, let sessionID = state.liveSessionID else {
+      return .merge(runningChanged(false, state), drain)
+    }
     return .merge(
       runningChanged(false, state),
-      refreshAfterSlashCommand(sessionID: sessionID, profile: state.scopedProfile)
+      refreshAfterSlashCommand(sessionID: sessionID, profile: state.scopedProfile),
+      drain
     )
   }
 
@@ -3441,6 +3552,7 @@ private func submitPrompt(
   profile: String?,
   gateway: HermesGatewayClient,
   send: Send<ChatFeature.Action>,
+  queuedPromptID: UUID? = nil,
   submit: @escaping (_ targetID: String) async throws -> Void
 ) async {
   do {
@@ -3448,6 +3560,7 @@ private func submitPrompt(
       submit, sessionID: sessionID, storedSessionID: storedSessionID,
       branchSeed: branchSeed, profile: profile, gateway: gateway, send: send
     )
+    if let queuedPromptID { await send(.queuedPromptAccepted(id: queuedPromptID)) }
   } catch let error as GatewayError {
     await send(.promptSubmitFailed(message: error.message))
   } catch {

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -1032,6 +1032,58 @@ struct ChatReductionTests {
     await store.send(.teardown)
   }
 
+  @Test func activateDoesNotDuplicateInflightUserAlreadyInMessages() async {
+    // Regression: during a running turn the backend may expose the submitted user prompt in
+    // both authoritative `messages` and `inflight.user`. A hydrate must render one bubble.
+    let store = TestStore(initialState: ChatFeature.State(connection: conn, resumeStoredID: "stored123")) {
+      ChatFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+      $0.continuousClock = TestClock()
+      $0.date = .constant(.init(timeIntervalSince1970: 0))
+      $0.hermesGateway.send = { @Sendable _, _ in
+        .object([
+          "session_id": .string("live123"),
+          "stored_session_id": .string("stored123"),
+          "messages": .array([
+            .object([
+              "id": .number(1),
+              "role": .string("user"),
+              "content": .string("What are your thoughts on this current rule set?"),
+            ]),
+          ]),
+          "running": .bool(true),
+          "info": .object([
+            "model": .string("gpt-5.6-sol"),
+            "usage": .object([
+              "context_used": .number(5),
+              "context_max": .number(200_000),
+              "context_percent": .number(0),
+            ]),
+          ]),
+          "inflight": .object([
+            "user": .string("What are your thoughts on this current rule set?"),
+            "assistant": .string(""),
+            "streaming": .bool(true),
+          ]),
+        ])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.gatewayEvent(.ready))
+    await store.receive(\.activateResult.success)
+
+    let matchingUserRows = store.state.transcript.filter { row in
+      if case let .message(role, text, _) = row.kind {
+        return role == .user && text == "What are your thoughts on this current rule set?"
+      }
+      return false
+    }
+    #expect(matchingUserRows.count == 1)
+    await store.send(.teardown)
+  }
+
   @Test func unknownEventIsInertInTheFold() async {
     let store = TestStore(initialState: ChatFeature.State(connection: conn)) {
       ChatFeature()

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -618,20 +618,32 @@ struct ChatReductionTests {
     #expect(didSend.value == false)
   }
 
-  // The visible send button becomes the interrupt button mid-turn, but a hardware-keyboard
-  // return still fires the TextField's `.onSubmit`. A submit while a turn streams must be a
-  // strict no-op — a second in-flight submit corrupts `isSending`, and if it later failed it
-  // would emit a spurious `runningChanged(false)` that tears down a detached slot whose
-  // first turn is still genuinely running. Exhaustive: any state change or effect fails this.
-  @Test func submitWhileSendingIsNoOp() async {
+  // Hardware return while a turn streams is queue input, never a second prompt.submit.
+  // The active turn stays running while the draft is captured and the composer clears.
+  @Test func submitWhileSendingQueuesWithoutSecondRPC() async {
+    let didSend = LockIsolated(false)
     var initial = ChatFeature.State(connection: conn, status: .ready)
     initial.liveSessionID = "live"
     initial.composerText = "second message typed mid-turn"
     initial.isSending = true
-    let store = TestStore(initialState: initial) { ChatFeature() }
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.hermesGateway.send = { @Sendable _, _ in
+        didSend.setValue(true)
+        return .object([:])
+      }
+    }
 
     #expect(initial.canSend == false)
-    await store.send(.composerSubmitted)
+    #expect(initial.canQueue)
+    await store.send(.composerSubmitted) {
+      $0.composerText = ""
+      $0.queuedPrompts = [.init(
+        id: self.uuid(0), text: "second message typed mid-turn", attachments: []
+      )]
+    }
+    #expect(store.state.isSending)
+    #expect(didSend.value == false)
   }
 
   // MARK: Bootstrap (create on first ready)
@@ -2045,5 +2057,204 @@ struct ChatReductionTests {
     #expect(store.state.expectsPendingApproval == false)
 
     await store.send(.teardown)
+  }
+
+  @Test func capturedComposerSubmitClearsFieldAndSubmitsExactlyOnce() async {
+    let calls = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.composerText = "send once"
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, _ in
+        calls.withValue { $0.append(method) }
+        return .object(["status": .string("streaming")])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted)
+    await store.finish()
+
+    #expect(store.state.composerText.isEmpty)
+    #expect(store.state.transcript.filter { $0.kind == .message(role: .user, text: "send once", isComplete: true) }.count == 1)
+    #expect(calls.value == ["prompt.submit"])
+  }
+
+  @Test func busySubmitQueuesTextAndAttachmentsWithoutSecondRPC() async {
+    let calls = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.isSending = true
+    initial.composerText = "next task"
+    initial.attachments = [ComposerAttachment(
+      id: uuid(99), kind: .image, filename: "screen.png", mimeType: "image/png", data: Data([1])
+    )]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.hermesGateway.send = { @Sendable method, _ in
+        calls.withValue { $0.append(method) }
+        return .object([:])
+      }
+    }
+
+    await store.send(.composerSubmitted) {
+      $0.queuedPrompts = [.init(
+        id: self.uuid(0), text: "next task",
+        attachments: [ComposerAttachment(
+          id: self.uuid(99), kind: .image, filename: "screen.png", mimeType: "image/png", data: Data([1])
+        )]
+      )]
+      $0.composerText = ""
+      $0.attachments = []
+    }
+    #expect(store.state.isSending)
+    #expect(calls.value.isEmpty)
+  }
+
+  @Test func queuedPromptAutoDrainsAfterCurrentTurnCompletes() async {
+    let submitted = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.isSending = true
+    initial.queuedPrompts = [.init(id: uuid(80), text: "follow up", attachments: [])]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        if method == "prompt.submit", let text = params["text"]?.stringValue {
+          submitted.withValue { $0.append(text) }
+        }
+        return .object(["status": .string("streaming")])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.gatewayEvent(.messageComplete(text: "done", usage: nil)))
+    await store.receive(\.queuedPromptDrainRequested)
+    await store.receive(\.composerSubmitted)
+    await store.finish()
+
+    #expect(store.state.queuedPrompts.isEmpty)
+    #expect(store.state.composerText.isEmpty)
+    #expect(store.state.isSending)
+    #expect(submitted.value == ["follow up"])
+  }
+
+  @Test func newDraftCannotOvertakeAnOlderQueuedPrompt() async {
+    let submitted = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.composerText = "newer draft"
+    initial.queuedPrompts = [.init(id: uuid(80), text: "older queued", attachments: [])]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        if method == "prompt.submit", let text = params["text"]?.stringValue {
+          submitted.withValue { $0.append(text) }
+        }
+        return .object(["status": .string("streaming")])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.composerSubmitted)
+    await store.receive(\.queuedPromptDrainRequested)
+    await store.receive(\.composerSubmitted)
+    await store.finish()
+
+    #expect(submitted.value == ["older queued"])
+    #expect(store.state.queuedPrompts.map(\.text) == ["newer draft"])
+    #expect(store.state.isSending)
+  }
+
+  @Test func hydrateDrainsQueueWhenCompletionWasMissedOffline() async {
+    let submitted = LockIsolated<[String]>([])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.isSending = true
+    initial.queuedPrompts = [.init(id: uuid(80), text: "offline follow up", attachments: [])]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable method, params in
+        if method == "prompt.submit", let text = params["text"]?.stringValue {
+          submitted.withValue { $0.append(text) }
+        }
+        return .object(["status": .string("streaming")])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.activateResult(.success(activateResponse(running: false))))
+    await store.receive(\.queuedPromptDrainRequested)
+    await store.receive(\.composerSubmitted)
+    await store.receive(\.queuedPromptAccepted)
+    await store.finish()
+
+    #expect(submitted.value == ["offline follow up"])
+    #expect(store.state.queuedPrompts.isEmpty)
+    #expect(store.state.activeQueuedPrompt == nil)
+    #expect(store.state.isSending)
+  }
+
+  @Test func queuedSubmitFailureRestoresHeadWithoutLosingFIFO() async {
+    let failed = ChatFeature.State.QueuedPrompt(id: uuid(80), text: "retry me", attachments: [])
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.isSending = true
+    initial.activeQueuedPrompt = failed
+    initial.queuedPrompts = [.init(id: uuid(81), text: "later", attachments: [])]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.promptSubmitFailed(message: "offline"))
+    await store.finish()
+
+    #expect(store.state.activeQueuedPrompt == nil)
+    #expect(store.state.queuedPrompts.map(\.text) == ["retry me", "later"])
+    #expect(!store.state.isSending)
+  }
+
+  @Test func completedQueuedSlashCommandDrainsNextPrompt() async {
+    var initial = ChatFeature.State(connection: conn)
+    initial.liveSessionID = "live123"
+    initial.isSending = true
+    initial.slashExecInFlight = true
+    initial.activeQueuedPrompt = .init(id: uuid(80), text: "/title New", attachments: [])
+    initial.queuedPrompts = [.init(id: uuid(81), text: "continue", attachments: [])]
+    let store = TestStore(initialState: initial) { ChatFeature() } withDependencies: {
+      $0.uuid = .incrementing
+      $0.date = .constant(Date(timeIntervalSince1970: 0))
+      $0.continuousClock = ImmediateClock()
+      $0.chatSnapshot = .inMemory()
+      $0.hermesGateway.send = { @Sendable _, _ in
+        .object(["status": .string("streaming")])
+      }
+    }
+    store.exhaustivity = .off(showSkippedAssertions: false)
+
+    await store.send(.slashCommandFailed(message: "finished"))
+    await store.receive(\.queuedPromptDrainRequested)
+    await store.receive(\.composerSubmitted)
+    await store.receive(\.queuedPromptAccepted)
+    await store.finish()
+
+    #expect(store.state.activeQueuedPrompt == nil)
+    #expect(store.state.queuedPrompts.isEmpty)
+    #expect(store.state.isSending)
   }
 }

--- a/HermesMobile/Sources/Features/Chat/ChatView.swift
+++ b/HermesMobile/Sources/Features/Chat/ChatView.swift
@@ -20,12 +20,14 @@ struct ChatView: View {
         }
       footer
       pendingCard
+      queuedPromptBar
       suggestionPanel
       Divider()
       ComposerView(
         text: $store.composerText,
         isSending: store.isSending,
         canSend: store.canSend,
+        canQueue: store.canQueue,
         model: store.model,
         reasoningEffort: store.reasoningEffort,
         usage: store.usage,
@@ -95,6 +97,44 @@ struct ChatView: View {
           onDone: { store.send(.modelPickerDismissed) }
         )
       }
+    }
+  }
+
+  @ViewBuilder
+  private var queuedPromptBar: some View {
+    if let first = store.queuedPrompts.first {
+      HStack(spacing: 8) {
+        Image(systemName: "square.stack.3d.up.fill")
+          .foregroundStyle(Color.hermesAccent)
+        Text("Queued \(store.queuedPrompts.count)")
+          .font(.caption.weight(.semibold))
+        Text(first.text.isEmpty ? first.attachments.map(\.filename).joined(separator: ", ") : first.text)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+        Spacer(minLength: 4)
+        if !store.isSending {
+          Button {
+            store.send(.queuedPromptDrainRequested)
+          } label: {
+            Image(systemName: "play.circle.fill")
+          }
+          .buttonStyle(.plain)
+          .foregroundStyle(Color.hermesAccent)
+          .accessibilityLabel("Send next queued message")
+        }
+        Button {
+          store.send(.removeQueuedPrompt(id: first.id))
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(.secondary)
+        .accessibilityLabel("Remove next queued message")
+      }
+      .padding(.horizontal, 18)
+      .padding(.vertical, 7)
+      .background(Color(uiColor: .secondarySystemBackground))
     }
   }
 

--- a/HermesMobile/Sources/Features/Chat/ComposerView.swift
+++ b/HermesMobile/Sources/Features/Chat/ComposerView.swift
@@ -9,6 +9,7 @@ struct ComposerView: View {
   @Binding var text: String
   let isSending: Bool
   let canSend: Bool
+  var canQueue: Bool = false
   let model: String?
   let reasoningEffort: String?
   /// Context-window usage (#4): a compact gauge beside the model chip. Hidden when nil or
@@ -53,7 +54,7 @@ struct ComposerView: View {
       TextField("Message", text: $text, axis: .vertical)
         .lineLimit(1 ... 6)
         .focused(focused)
-        .onSubmit(onSend)
+        .onSubmit(submitDraft)
 
       HStack(spacing: 12) {
         // Let the model chip claim its ideal width before the Spacer, so the model name
@@ -163,16 +164,35 @@ struct ComposerView: View {
   @ViewBuilder
   private var sendButton: some View {
     if isSending {
+      if canQueue {
+        Button(action: submitDraft) {
+          Image(systemName: "square.stack.3d.up.fill").font(.title2)
+        }
+        .foregroundStyle(Color.hermesAccent)
+        .accessibilityLabel("Queue message")
+      }
       Button(action: onInterrupt) {
         Image(systemName: "stop.circle.fill").font(.title)
       }
       .foregroundStyle(.red)
+      .accessibilityLabel("Stop current task")
     } else {
-      Button(action: onSend) {
+      Button(action: submitDraft) {
         Image(systemName: "arrow.up.circle.fill").font(.title)
       }
       .foregroundStyle(Color.hermesAccent)
       .disabled(!canSend)
+    }
+  }
+
+  /// Submit synchronously and reinforce an accepted reducer clear at the focused field
+  /// boundary. Rejected submissions and attachment uploads intentionally keep their draft.
+  private func submitDraft() {
+    let original = text
+    onSend()
+    if text.isEmpty || text != original {
+      // A second binding write closes iOS's TextField/onSubmit stale-repaint race.
+      text = ""
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent duplicate user bubbles when `inflight.user` already matches the authoritative transcript
- clear accepted composer submissions at both reducer and SwiftUI binding boundaries without erasing rejected drafts or failed attachment uploads
- allow text and attachments entered during an active turn to queue client-side instead of issuing concurrent `prompt.submit` calls
- submit queued prompts FIFO after each turn completes, after reconnect hydration detects a missed completion, and after queued slash commands finish
- preserve failed queue heads for retry/removal rather than dropping them
- show the pending queue in chat with remove and manual send-next controls

## Why
The iOS companion could render/send the same prompt twice while leaving the original text in the composer. It also required stopping the active turn before another prompt could be submitted. This aligns mobile behavior with Hermes Desktop/TUI queued messages.

## Verification
- `swift test`: **953 tests in 56 suites passed**, 0 failures
- iOS Simulator Debug build succeeded:
  `xcodebuild build -workspace HermesMobile.xcworkspace -scheme HermesMobile -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO -skipMacroValidation -quiet`
- `git diff --check` clean

## Regression coverage
- duplicate `inflight.user` hydrate suppression
- accepted composer clear and one-shot submit
- busy Return/send queues without a second RPC
- queued attachments retain their payload
- automatic FIFO drain after completion
- newer drafts cannot overtake older queued prompts
- reconnect hydration drains work when completion was missed offline
- failed queued submit restores the queue head
- queued slash completion drains the next prompt
