### PR TITLE
Insert a newline on Return instead of sending

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,10 +519,14 @@ build/test/distribution, and `docs/plans/completed/` for the full design history
   `TextField`: a `TextField` never claims `paste(_:)` for a non-text clipboard, so for an
   image-only one iOS does not even *offer* the **Paste** item (measured in the simulator — see
   the plan's Task 8 notes). Everything else about the view is deliberate
-  `TextField(axis: .vertical)` parity — placeholder colour, 1–6 line growth, Return submits,
-  Shift+Return inserts — and the UIKit traps that parity costs (the `setNeedsLayout` the pinned
+  `TextField(axis: .vertical)` parity — placeholder colour, 1–6 line growth — and the UIKit traps
+  that parity costs (the `setNeedsLayout` the pinned
   ceiling needs, the one-shot `scrollRangeToVisible` on the scroll flip, the caret pin after a
-  programmatic set) are documented on the type itself. There is deliberately **no focus
+  programmatic set) are documented on the type itself. **The Return key is the one deliberate
+  departure** (#70): it inserts a newline like any other edit, and the **send button is the only
+  submit path** — the view intercepts nothing (the old `shouldChangeTextIn` `\n` swallow and its
+  `onSubmit`/Shift+Return key-command workaround are gone), so `ChatFeature`'s `canSend` guards
+  are now defence-in-depth rather than a live route. There is deliberately **no focus
   binding**: a representable gets no `.focused(_:)` — it *is* the focusable view — so a
   `@FocusState` here never latches and reading it only ever resigns the keyboard (it did: the
   composer lost the keyboard after one keystroke). The transcript dismisses the keyboard at the

--- a/HermesKit/Package.resolved
+++ b/HermesKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ae4d1524cc192a602664288bc3dc3f86590adf836146ee84b682b7cf4f2d1951",
+  "originHash" : "25ffac1c67223f8cf8c5e8d3fc4e295a5a2a04bc004fb1de2519a4f1c6567192",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -116,6 +116,15 @@
       "state" : {
         "revision" : "c525e53936c878c102421eee241d82711eb38104",
         "version" : "2.8.1"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "1bc16f430d8410e7f087d4c787767b26fd32fe30",
+        "version" : "1.19.3"
       }
     },
     {

--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -461,11 +461,12 @@ public struct ChatFeature {
         // self-heal `session.create` (two live sessions born from one seed).
         && liveSessionID != nil
         && pendingInteraction == nil
-        // The visible send button becomes the interrupt button mid-turn, but a hardware-
-        // keyboard return still fires the TextField's `.onSubmit` — a second submit while a
-        // turn streams must be a no-op (it would corrupt `isSending` and, if it later
-        // failed, emit a spurious `runningChanged(false)` that tears down a detached slot
-        // whose first turn is still genuinely running).
+        // The visible send button becomes the interrupt button mid-turn, so this is
+        // defence-in-depth against a `.composerSubmitted` that races the swap (a tap already
+        // in flight, a stale view). A second submit while a turn streams must be a no-op (it
+        // would corrupt `isSending` and, if it later failed, emit a spurious
+        // `runningChanged(false)` that tears down a detached slot whose first turn is still
+        // genuinely running).
         && !isSending
         // A slash exec locks the composer via `isSending` too, but `isSending` can be
         // cleared out from under it — an interrupt tap (`.interruptTapped`) or a socket

--- a/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatReductionTests.swift
@@ -618,8 +618,8 @@ struct ChatReductionTests {
     #expect(didSend.value == false)
   }
 
-  // The visible send button becomes the interrupt button mid-turn, but a hardware-keyboard
-  // return still fires the TextField's `.onSubmit`. A submit while a turn streams must be a
+  // The visible send button becomes the interrupt button mid-turn, but a `.composerSubmitted`
+  // can still race the swap. A submit while a turn streams must be a
   // strict no-op — a second in-flight submit corrupts `isSending`, and if it later failed it
   // would emit a spurious `runningChanged(false)` that tears down a detached slot whose
   // first turn is still genuinely running. Exhaustive: any state change or effect fails this.

--- a/HermesMobile/Sources/Features/Chat/ComposerTextView.swift
+++ b/HermesMobile/Sources/Features/Chat/ComposerTextView.swift
@@ -4,8 +4,13 @@ import SwiftUI
 import UIKit
 
 /// The composer's `UITextView`: `TextField` parity (placeholder, 1–`maxLines` growth, the
-/// scroll flip past the ceiling, Shift+Return) plus the image-paste interception it was
-/// swapped in for (#54).
+/// scroll flip past the ceiling) plus the image-paste interception it was swapped in for (#54).
+///
+/// **Return inserts a newline; the send button is the only way to submit** (#70). The field
+/// deliberately intercepts nothing about the Return key — the delegate hook that used to swallow
+/// a lone `"\n"` and call `onSubmit` is gone, along with the Shift+Return key command that
+/// existed only to route *around* it. A multi-line prompt is the common case here, and a
+/// keyboard-triggered send was too easy to hit mid-thought.
 ///
 /// SwiftUI's `TextField` never claims `paste(_:)` for a non-text clipboard, so for an
 /// image-only clipboard iOS does not even offer the **Paste** menu item. Two UIKit hooks fix
@@ -202,46 +207,14 @@ class ComposerInputTextView: UITextView {
     // immediately (the flag already matches).
     if shouldScroll { scrollRangeToVisible(selectedRange) }
   }
-
-  /// Hardware **Shift+Return** inserts a newline instead of submitting.
-  ///
-  /// Parity with the `TextField(axis: .vertical)` this replaced, whose Return submitted while
-  /// Shift+Return inserted. Without the key command the shifted Return arrives at the
-  /// delegate as an ordinary `"\n"` insertion, indistinguishable from the plain one, and
-  /// would submit. (Plain Return deliberately has no key command, so it still reaches
-  /// `shouldChangeTextIn` and submits there — the only hook the software keyboard offers.)
-  override var keyCommands: [UIKeyCommand]? {
-    let newline = UIKeyCommand(
-      input: "\r", modifierFlags: .shift, action: #selector(insertNewlineWithoutSubmitting)
-    )
-    // The text input system would otherwise handle the shifted Return itself, before any key
-    // command is consulted.
-    newline.wantsPriorityOverSystemBehavior = true
-    // `UIResponder`'s default is `nil` and `UITextView` declares no public override, so this
-    // chain is inert today — but overriding a responder's key commands without it would
-    // silently drop whatever a future OS defines there.
-    return (super.keyCommands ?? []) + [newline]
-  }
-
-  /// Set while `insertNewlineWithoutSubmitting` runs. `insertText(_:)` consults the delegate
-  /// like any other edit, so without this flag the newline it inserts would be caught by the
-  /// very interception it is meant to bypass — and Shift+Return would submit after all.
-  private(set) var isInsertingHardNewline = false
-
-  /// The Shift+Return action: an ordinary newline insertion (undo, typing attributes and
-  /// `textViewDidChange` all keep working) with the submit interception suppressed. Internal
-  /// so a test can drive it without a hardware keyboard.
-  @objc func insertNewlineWithoutSubmitting() {
-    isInsertingHardNewline = true
-    defer { isInsertingHardNewline = false }
-    insertText("\n")
-  }
 }
 
 /// The composer's text input: a `UITextView`-backed replacement for
 /// `TextField("Message", text:, axis: .vertical).lineLimit(1 ... 6)`, swapped in so a
 /// clipboard image can be intercepted (#54). Everything else is deliberate parity — the
-/// placeholder, 1–6 line growth, Return-key submit, and the body font/clear background.
+/// placeholder, 1–6 line growth, and the body font/clear background. The one departure is the
+/// Return key, which inserts a newline rather than submitting (#70): sending is the send
+/// button's job alone.
 ///
 /// There is deliberately **no focus binding**: a representable gets no `.focused(_:)` — it
 /// *is* the focusable view — so a `@FocusState` here would never latch and reading it would
@@ -271,17 +244,14 @@ struct ComposerTextView: UIViewRepresentable {
   /// **Resign, not disable.** The field stays live and editable, so a user who deliberately
   /// taps it can still draft their next message while they think about the card (the card's
   /// bounded region absorbs the keyboard coming back — that is what it is built for).
-  /// *Live* means typing, not sending: **Return is a silent no-op while a card stands** —
-  /// `shouldChangeTextIn` swallows the `\n` and routes it to `onSubmit`, which `canSend`
-  /// (false on any `pendingInteraction`) then drops, so the draft neither goes out nor gains
-  /// a newline. Pre-existing and unchanged here; Shift+Return still inserts one. It fires
+  /// *Live* means typing, not sending: Return only ever inserts a newline (#70), and Send is
+  /// disabled by `canSend` (false on any `pendingInteraction`), so a draft written under a
+  /// card cannot escape it. It fires
   /// once per *raised card*, keyed on the token rather than on `nil`-ness, so a replacement
   /// card drops the keyboard too and a re-focus is never fought over: `ChatView` re-renders on
   /// every streamed token, and an unkeyed "resign while blocked" would resign again on each one,
   /// making the field untappable in all but name.
   var blockingCardToken: Int?
-  /// Return key — matches `TextField(axis: .vertical).onSubmit`.
-  var onSubmit: () -> Void = {}
   /// Fired **synchronously** the moment a paste is claimed, before its providers have loaded.
   ///
   /// The load is asynchronous and, unlike a picker's, has no modal sheet covering it — the user
@@ -406,25 +376,6 @@ struct ComposerTextView: UIViewRepresentable {
       // `layoutSubviews` — and with it the scroll flip — unrun, stranding the new text out of
       // view. (A programmatic set is covered by the `text` observer.)
       textView.setNeedsLayout()
-    }
-
-    /// A lone Return submits instead of inserting a newline — the `TextField(axis: .vertical)`
-    /// contract this replaced.
-    ///
-    /// The text-replacement hook is the only one the *software* keyboard offers, so the
-    /// interception is necessarily "an inserted lone `\n`". A hardware **Shift+Return** is
-    /// therefore routed around it by `ComposerInputTextView.keyCommands`, which flags its
-    /// own insertion. Keyboard dictation's "new line" still submits — indistinguishable from a
-    /// Return at this layer, and the accepted cost of software-keyboard parity.
-    func textView(
-      _ textView: UITextView,
-      shouldChangeTextIn range: NSRange,
-      replacementText text: String
-    ) -> Bool {
-      if (textView as? ComposerInputTextView)?.isInsertingHardNewline == true { return true }
-      guard text == "\n" else { return true }
-      parent.onSubmit()
-      return false
     }
 
     /// Load the pasted providers' original bytes **asynchronously** — the loader is

--- a/HermesMobile/Sources/Features/Chat/ComposerView.swift
+++ b/HermesMobile/Sources/Features/Chat/ComposerView.swift
@@ -61,15 +61,15 @@ struct ComposerView: View {
     VStack(spacing: 10) {
       if !attachments.isEmpty { attachmentChips }
       // A `UITextView`-backed field rather than `TextField(axis: .vertical)`: only UIKit
-      // exposes the paste hooks an image paste needs (#54). Placeholder, 1–6 line growth and
-      // Return-key submit are parity with what it replaced (all defaulted on the type).
+      // exposes the paste hooks an image paste needs (#54). Placeholder and 1–6 line growth are
+      // parity with what it replaced (all defaulted on the type); Return inserts a newline and
+      // `sendButton` is the only way to submit (#70).
       ComposerTextView(
         text: $text,
         // Same capability gate as the paperclip: no Paste offer for an image-only clipboard
         // when the agent can't accept uploads.
         attachmentsSupported: attachmentsSupported,
         blockingCardToken: blockingCardToken,
-        onSubmit: onSend,
         onPasteBegan: onPasteBegan,
         onPasteImages: onPasteImages
       )

--- a/HermesMobileTests/ComposerTextViewTests.swift
+++ b/HermesMobileTests/ComposerTextViewTests.swift
@@ -721,54 +721,36 @@ final class ComposerTextViewTests: XCTestCase {
 
   // MARK: - Return key
 
-  /// Parity with `TextField(axis: .vertical).onSubmit`: a lone Return submits instead of
-  /// inserting a newline. The simulator can only show the *absence* of the newline (a real
-  /// submit needs a live session), so the hand-off itself is pinned here.
-  func testReturnSubmitsInsteadOfInsertingANewline() {
-    var submits = 0
-    let composer = ComposerTextView(text: .constant(""), onSubmit: { submits += 1 })
-    let coordinator = composer.makeCoordinator()
-    let textView = ComposerInputTextView()
-    let range = NSRange(location: 0, length: 0)
-
-    XCTAssertFalse(
-      coordinator.textView(textView, shouldChangeTextIn: range, replacementText: "\n"),
-      "the newline must not reach the text buffer"
+  /// Return inserts a newline and sends nothing (#70) — the composer has no keyboard submit
+  /// path at all, so a Return is an ordinary edit that reaches the buffer *and* the binding.
+  ///
+  /// `insertText` is what the software keyboard's Return does: it consults the delegate like
+  /// any other edit, so a re-introduced `shouldChangeTextIn` interception fails this outright.
+  func testReturnInsertsANewlineAndNeverSubmits() {
+    let writes = Recorder<String>()
+    let composer = ComposerTextView(
+      text: Binding(get: { writes.values.last ?? "" }, set: { writes.values.append($0) })
     )
-    XCTAssertEqual(submits, 1)
-
-    // Ordinary edits — including a pasted multi-line string — are untouched.
-    XCTAssertTrue(coordinator.textView(textView, shouldChangeTextIn: range, replacementText: "a"))
-    XCTAssertTrue(coordinator.textView(textView, shouldChangeTextIn: range, replacementText: "a\nb"))
-    XCTAssertTrue(coordinator.textView(textView, shouldChangeTextIn: range, replacementText: ""))
-    XCTAssertEqual(submits, 1, "only a lone Return submits")
-  }
-
-  /// Hardware **Shift+Return** inserts a newline — what `TextField(axis: .vertical)` did, and
-  /// what the text-replacement interception alone cannot tell apart from a plain Return.
-  func testShiftReturnInsertsANewlineInsteadOfSubmitting() throws {
-    var submits = 0
-    let composer = ComposerTextView(text: .constant(""), onSubmit: { submits += 1 })
     let coordinator = composer.makeCoordinator()
     let view = ComposerInputTextView()
     view.delegate = coordinator
     view.text = "one"
     view.selectedRange = NSRange(location: 3, length: 0)
 
-    let command = try XCTUnwrap(
-      view.keyCommands?.first { $0.input == "\r" && $0.modifierFlags == .shift }
-    )
-    XCTAssertEqual(command.action, #selector(ComposerInputTextView.insertNewlineWithoutSubmitting))
+    view.insertText("\n")
+    view.insertText("two")
 
-    view.insertNewlineWithoutSubmitting()
+    XCTAssertEqual(view.text, "one\ntwo", "the newline reaches the text buffer")
+    XCTAssertEqual(writes.values.last, "one\ntwo", "…and the binding, so Send would carry it")
+  }
 
-    XCTAssertEqual(view.text, "one\n", "the newline reaches the buffer")
-    XCTAssertEqual(submits, 0, "…and nothing is sent")
-    // The flag is scoped to that one insertion: a plain Return still submits afterwards.
-    XCTAssertFalse(
-      coordinator.textView(view, shouldChangeTextIn: NSRange(location: 4, length: 0), replacementText: "\n")
-    )
-    XCTAssertEqual(submits, 1)
+  /// Nothing claims the Return key any more: the Shift+Return key command existed only to route
+  /// *around* the submit interception, and leaving it behind would make a shifted Return behave
+  /// differently from a plain one for no reason.
+  func testNoKeyCommandClaimsReturn() {
+    let view = ComposerInputTextView()
+
+    XCTAssertNil(view.keyCommands?.first { $0.input == "\r" })
   }
 
   // MARK: - Caret visibility

--- a/Project.swift
+++ b/Project.swift
@@ -77,7 +77,7 @@ let project = Project(
           "DEVELOPMENT_TEAM": .string(developmentTeam),
           "CODE_SIGN_STYLE": "Automatic",
           "MARKETING_VERSION": "1.0",
-          "CURRENT_PROJECT_VERSION": "55",
+          "CURRENT_PROJECT_VERSION": "56",
           // Production default (App Store / external TestFlight) — the orange "AppIcon".
           // Debug builds override to the blue "AppIconDev" below. INTERNAL TestFlight
           // archives the Release config but overrides the icon on the xcodebuild command


### PR DESCRIPTION
Closes #70.

Return in the composer now inserts a newline; the send button is the only submit path.

- Dropped `ComposerTextView.Coordinator`'s `shouldChangeTextIn` interception (which swallowed a lone `\n` and called `onSubmit`) and the `onSubmit` hook itself.
- Dropped the Shift+Return `UIKeyCommand` and its `isInsertingHardNewline` flag — they existed only to route *around* that interception, and a shifted Return now behaves like a plain one.
- `ChatFeature`'s `canSend` guards are unchanged; their comments now describe them as defence-in-depth rather than citing a keyboard-return route that no longer exists.

Tests: the two Return tests in `ComposerTextViewTests` are replaced by one that drives `insertText("\n")` through the delegate and asserts the newline reaches both the buffer and the binding, plus one pinning that nothing claims the Return key. HermesKit suite (1097 tests) and `ComposerTextViewTests` (25) pass. Verified in the simulator via demo mode: three Return presses produced a three-line draft and sent nothing.

Build 56 is uploading to TestFlight (internal) off this branch.