### PR TITLE
Dedupe session and profile ids from server responses to fix list trap

### DIFF
--- a/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
@@ -837,10 +837,14 @@ public struct SessionListFeature {
         // Belt-and-suspenders: drop any session whose archive PATCH or DELETE is still in
         // flight, so a fetch that completes during that window can't repopulate the removed row.
         let inFlight = state.archivingIDs.union(state.deletingIDs)
-        let visible = inFlight.isEmpty
+        let filtered = inFlight.isEmpty
           ? sessions
           : sessions.filter { !inFlight.contains($0.id) }
-        state.sessions = IdentifiedArray(uniqueElements: visible)
+        // The list AND search endpoints can return the same session id more than once
+        // (#78). `IdentifiedArray(uniqueElements:)` preconditions on unique ids and
+        // trapped in the field, so dedupe first — keep the FIRST occurrence (server order).
+        state.sessions = IdentifiedArray(filtered, uniquingIDsWith: { first, _ in first })
+        let visible = state.sessions
         // Seed last-seen counts for newly-discovered sessions so they don't all show as
         // unread on first sight; only later increases flag unread.
         var seeded = false
@@ -1255,7 +1259,7 @@ public struct SessionListFeature {
 
       case let .profilesResponse(.success(result)):
         state.profilesSupported = true
-        state.profiles = IdentifiedArray(uniqueElements: result)
+        state.profiles = Self.dedupedProfiles(result)
         // If the persisted selection no longer exists on the server, re-home to default.
         if state.profiles[id: state.selectedProfileName] == nil {
           state.selectedProfileName = Self.State.defaultProfileName
@@ -1271,7 +1275,7 @@ public struct SessionListFeature {
 
       case let .profilesRefreshed(result):
         state.profilesSupported = true
-        state.profiles = IdentifiedArray(uniqueElements: result)
+        state.profiles = Self.dedupedProfiles(result)
         return .none
 
       case let .selectProfile(name):
@@ -1570,6 +1574,12 @@ public struct SessionListFeature {
 
   private func persistPinnedIDs(_ ids: [String]) -> Effect<Action> {
     .run { [preferences] _ in preferences.savePinnedIDs(ids) }
+  }
+
+  /// Build the profile array tolerating a duplicate `name` in the server response (keep
+  /// the first occurrence) — `IdentifiedArray(uniqueElements:)` traps on duplicates (#78).
+  private static func dedupedProfiles(_ profiles: [Profile]) -> IdentifiedArrayOf<Profile> {
+    IdentifiedArray(profiles, uniquingIDsWith: { first, _ in first })
   }
 }
 

--- a/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
@@ -226,6 +226,125 @@ struct SessionListFeatureTests {
     }
   }
 
+  // MARK: Duplicate ids in the server response (#78)
+
+  /// The list AND search endpoints can return the same session id more than once;
+  /// `IdentifiedArray(uniqueElements:)` trapped on that in the field. The response must
+  /// dedupe by id, keeping the FIRST occurrence (server order), and seed `seenCounts`
+  /// from that first occurrence only.
+  @Test func sessionsResponseWithDuplicateIDsDedupesKeepingFirst() async {
+    let store = TestStore(initialState: SessionListFeature.State(connection: connection)) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.preferences = .inMemory()
+    }
+
+    await store.send(.sessionsResponse(.success([
+      Session(id: "a", title: "First a", messageCount: 3),
+      Session(id: "b", title: "b", messageCount: 1),
+      Session(id: "a", title: "Second a", messageCount: 9),
+      Session(id: "b", title: "b again"),
+    ]))) {
+      $0.isLoading = false
+      $0.sessions = [
+        Session(id: "a", title: "First a", messageCount: 3),
+        Session(id: "b", title: "b", messageCount: 1),
+      ]
+      $0.seenCounts = ["a": 3, "b": 1]
+    }
+    #expect(store.state.sessions.map(\.id) == ["a", "b"])
+  }
+
+  /// A duplicate that is also filtered by the in-flight archive/delete guard stays gone —
+  /// the guard filter and the dedupe compose (neither re-admits the removed row).
+  @Test func sessionsResponseWithDuplicateIDsRespectsInFlightGuard() async {
+    var initial = SessionListFeature.State(
+      connection: connection, sessions: [Session(id: "a"), Session(id: "b")]
+    )
+    initial.deletingIDs = ["a"]
+    let store = TestStore(initialState: initial) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.preferences = .inMemory()
+    }
+
+    await store.send(.sessionsResponse(.success([
+      Session(id: "a"), Session(id: "b"), Session(id: "a"), Session(id: "b"),
+    ]))) {
+      $0.isLoading = false
+      $0.sessions = [Session(id: "b")]
+      $0.seenCounts = ["b": 0]
+    }
+    #expect(store.state.seenCounts["a"] == nil)
+  }
+
+  /// End-to-end through the search path (the crash reports' primary trigger): the search
+  /// endpoint answering with a repeated id must land as a deduped list, not a trap.
+  @Test func searchResponseWithDuplicateIDsDoesNotTrap() async {
+    let clock = TestClock()
+    let store = TestStore(initialState: SessionListFeature.State(connection: connection)) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.hermesREST.search = { @Sendable _, query in
+        [
+          Session(id: "r1", title: nil, preview: query),
+          Session(id: "r2", title: nil, preview: query),
+          Session(id: "r1", title: "dup", preview: query),
+        ]
+      }
+      $0.continuousClock = clock
+      $0.preferences = .inMemory()
+    }
+
+    await store.send(\.binding.searchQuery, "foo") { $0.searchQuery = "foo" }
+    await clock.advance(by: .milliseconds(300))
+    await store.receive(\.sessionsResponse.success) {
+      $0.sessions = [
+        Session(id: "r1", title: nil, preview: "foo"),
+        Session(id: "r2", title: nil, preview: "foo"),
+      ]
+      $0.seenCounts = ["r1": 0, "r2": 0]
+    }
+  }
+
+  /// Same hardening for profiles: a duplicate `name` in `GET /api/profiles` (both the
+  /// initial probe and the post-create refresh) dedupes instead of trapping.
+  @Test func profilesResponseWithDuplicateNamesDedupesKeepingFirst() async {
+    let prefs = PreferencesClient.inMemory()
+    let store = TestStore(
+      initialState: SessionListFeature.State(connection: connection, selectedProfileName: "work")
+    ) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.date = .constant(now)
+      $0.preferences = prefs
+      $0.hermesREST.cronJobs = { @Sendable _, _ in throw RESTError.notFound }
+      $0.hermesProfiles.sessions = { @Sendable _, _, _, _, _, _ in [] }
+    }
+
+    let duplicated = [
+      Profile(name: "default", isDefault: true),
+      Profile(name: "work", model: "first"),
+      Profile(name: "work", model: "second"),
+    ]
+    await store.send(.profilesResponse(.success(duplicated))) {
+      $0.profilesSupported = true
+      $0.profiles = [Profile(name: "default", isDefault: true), Profile(name: "work", model: "first")]
+      $0.now = self.now
+      $0.isLoading = true
+    }
+    await store.receive(\.sessionsResponse.success) {
+      $0.isLoading = false
+    }
+    await store.receive(\.cronJobsResponse.failure) {
+      $0.cronJobsSupported = false
+    }
+
+    await store.send(.profilesRefreshed(duplicated))
+    #expect(store.state.profiles.map(\.id) == ["default", "work"])
+    #expect(store.state.profiles[id: "work"]?.model == "first")
+  }
+
   @Test func tappingSessionEmitsOpenDelegateAndMarksSeen() async {
     let session = Session(id: "s1", title: "Hello", messageCount: 7)
     let store = TestStore(


### PR DESCRIPTION
Fixes #78

All five recent TestFlight crashes (1.0 (60)) were the same trap: `IdentifiedArray(uniqueElements:)` in `.sessionsResponse(.success)` preconditions on unique ids, and both the plain list fetch after connect and the search endpoint can return the same session id more than once.

**Changes**
- `.sessionsResponse(.success)`: build `state.sessions` with `IdentifiedArray(_:uniquingIDsWith:)`, keeping the first occurrence (server order). The in-flight archive/delete filter still runs first, and `seenCounts` seeding now iterates the deduped array.
- `.profilesResponse(.success)` / `.profilesRefreshed`: same hardening via a small `dedupedProfiles` helper (a duplicate profile `name` would have trapped identically).

**Tests** (`SessionListFeatureTests`)
- `sessionsResponseWithDuplicateIDsDedupesKeepingFirst` — duplicate ids collapse to the first occurrence; `seenCounts` seeded from it.
- `sessionsResponseWithDuplicateIDsRespectsInFlightGuard` — dedupe composes with the `deletingIDs` guard.
- `searchResponseWithDuplicateIDsDoesNotTrap` — end-to-end through the debounced search path (the crash reports' main trigger).
- `profilesResponseWithDuplicateNamesDedupesKeepingFirst` — both profile entry points.

`swift test` (HermesKit): 1179 tests in 60 suites pass.

Not addressed here: why the agent's list/search endpoints emit duplicates (server side — worth a look in the Hermes repo).

https://claude.ai/code/session_01G4bh3yJAbnSBCmGrQZy6ge