### PR TITLE
feat: toggle to show/hide the Cron Jobs section in the session list

### DIFF
--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -296,6 +296,7 @@ public struct AppFeature {
         preferences.clearIdentityScopedPrefs()
         preferences.saveGroupingMode(.default)
         preferences.saveDefaultSessionSwipeAction(.default)
+        preferences.saveShowCronSection(true)
         state.connectionFailed = nil
         state.path = .init()
         state.liveChat = nil
@@ -635,6 +636,7 @@ public struct AppFeature {
         preferences.clearIdentityScopedPrefs()
         preferences.saveGroupingMode(.default)
         preferences.saveDefaultSessionSwipeAction(.default)
+        preferences.saveShowCronSection(true)
         state.reauth = nil
         state.path = .init()
         state.liveChat = nil

--- a/HermesKit/Sources/HermesKit/Clients/PreferencesClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/PreferencesClient.swift
@@ -24,6 +24,10 @@ public struct PreferencesClient: Sendable {
   /// (archive vs permanent delete). Device-local UI pref; reset on logout.
   public var loadDefaultSessionSwipeAction: @Sendable () -> SessionSwipeAction = { .default }
   public var saveDefaultSessionSwipeAction: @Sendable (_ action: SessionSwipeAction) -> Void
+  /// Whether the session list shows the always-on "Cron Jobs" section. Device-local UI
+  /// pref; defaults to `true` (shown) so the section stays visible until the user opts out.
+  public var loadShowCronSection: @Sendable () -> Bool = { true }
+  public var saveShowCronSection: @Sendable (_ show: Bool) -> Void
   /// Currently selected Hermes profile name. Device-local — we never change the server's
   /// sticky active profile. `nil` means the default profile.
   public var loadSelectedProfileID: @Sendable () -> String? = { nil }
@@ -63,6 +67,7 @@ public extension PreferencesClient {
     let pinnedKey = "hermes.pinned-session-ids"
     let groupingKey = "hermes.session-grouping-mode"
     let swipeActionKey = "hermes.default-session-swipe-action"
+    let showCronSectionKey = "hermes.show-cron-section"
     let selectedProfileKey = "hermes.selected-profile-id"
     let pushTokenKey = "hermes.push-device-token"
     let pushSnoozeCountKey = "hermes.push-prompt-snooze-count"
@@ -85,6 +90,13 @@ public extension PreferencesClient {
         store.string(forKey: swipeActionKey).flatMap(SessionSwipeAction.init(rawValue:)) ?? .default
       },
       saveDefaultSessionSwipeAction: { store.set($0.rawValue, forKey: swipeActionKey) },
+      loadShowCronSection: {
+        // Absent key (never toggled) means shown — the section is on by default.
+        store.object(forKey: showCronSectionKey) == nil
+          ? true
+          : store.bool(forKey: showCronSectionKey)
+      },
+      saveShowCronSection: { store.set($0, forKey: showCronSectionKey) },
       loadSelectedProfileID: { store.string(forKey: selectedProfileKey) },
       saveSelectedProfileID: { store.set($0, forKey: selectedProfileKey) },
       clearSelectedProfileID: { store.removeObject(forKey: selectedProfileKey) },
@@ -115,6 +127,7 @@ public extension PreferencesClient {
     let pinned = LockIsolated<[String]>([])
     let grouping = LockIsolated<SessionGroupingMode>(.default)
     let swipeAction = LockIsolated<SessionSwipeAction>(.default)
+    let showCronSection = LockIsolated<Bool>(true)
     let selectedProfile = LockIsolated<String?>(nil)
     let pushToken = LockIsolated<String?>(nil)
     let pushSnooze = LockIsolated<(count: Int, until: Date)?>(nil)
@@ -130,6 +143,8 @@ public extension PreferencesClient {
       saveGroupingMode: { grouping.setValue($0) },
       loadDefaultSessionSwipeAction: { swipeAction.value },
       saveDefaultSessionSwipeAction: { swipeAction.setValue($0) },
+      loadShowCronSection: { showCronSection.value },
+      saveShowCronSection: { showCronSection.setValue($0) },
       loadSelectedProfileID: { selectedProfile.value },
       saveSelectedProfileID: { selectedProfile.setValue($0) },
       clearSelectedProfileID: { selectedProfile.setValue(nil) },

--- a/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
@@ -62,6 +62,9 @@ public struct SessionListFeature {
     /// loaded with the other prefs. Views must read `effectiveSwipeAction`, which clamps
     /// this to `.archive` while the agent lacks the DELETE capability.
     public var defaultSwipeAction: SessionSwipeAction
+    /// Whether the always-on "Cron Jobs" section is shown. Device-local UI pref, seeded
+    /// from prefs on load; toggled from the organize menu. Defaults to `true` (shown).
+    public var showCronSection: Bool
     /// Ids whose rename PATCH is currently IN FLIGHT. Transient: added when the PATCH starts,
     /// removed on success/failure. While non-empty the poll skips (like `archivingIDs`) so a
     /// fetch landing mid-PATCH can't clobber the optimistic title with the server's old one.
@@ -157,6 +160,7 @@ public struct SessionListFeature {
       deletingIDs: Set<String> = [],
       deleteSupported: Bool = true,
       defaultSwipeAction: SessionSwipeAction = .default,
+      showCronSection: Bool = true,
       renamingInFlightIDs: Set<String> = [],
       renamingID: Session.ID? = nil,
       renameDraft: String = "",
@@ -189,6 +193,7 @@ public struct SessionListFeature {
       self.deletingIDs = deletingIDs
       self.deleteSupported = deleteSupported
       self.defaultSwipeAction = defaultSwipeAction
+      self.showCronSection = showCronSection
       self.renamingInFlightIDs = renamingInFlightIDs
       self.renamingID = renamingID
       self.renameDraft = renameDraft
@@ -394,6 +399,8 @@ public struct SessionListFeature {
     case toggleGroupExpansion(groupID: String)
     /// Switch the list grouping (workspace/chronological) and persist the choice.
     case setGroupingMode(SessionGroupingMode)
+    /// Toggle the always-on "Cron Jobs" section and persist the choice.
+    case setShowCronSection(Bool)
     case archiveButtonTapped(id: Session.ID)
     /// Archive RPC succeeded — clear the transient in-flight guard and cancel (or, when
     /// one is pending, restart — see `cancelOrRestartFetch`) any fetch that started
@@ -899,6 +906,11 @@ public struct SessionListFeature {
         guard state.groupingMode != mode else { return .none }
         state.groupingMode = mode
         return .run { [preferences] _ in preferences.saveGroupingMode(mode) }
+
+      case let .setShowCronSection(show):
+        guard state.showCronSection != show else { return .none }
+        state.showCronSection = show
+        return .run { [preferences] _ in preferences.saveShowCronSection(show) }
 
       case let .toggleGroupExpansion(groupID):
         if !state.expandedGroups.insert(groupID).inserted {
@@ -1455,6 +1467,7 @@ public struct SessionListFeature {
     state.pinnedIDs = preferences.loadPinnedIDs()
     state.groupingMode = preferences.loadGroupingMode()
     state.defaultSwipeAction = preferences.loadDefaultSessionSwipeAction()
+    state.showCronSection = preferences.loadShowCronSection()
   }
 
   /// Refresh "now", clear errors, reload persisted prefs, and fetch the session list

--- a/HermesKit/Sources/HermesKit/Features/SettingsFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SettingsFeature.swift
@@ -348,6 +348,7 @@ public struct SettingsFeature {
         preferences.saveSeenCounts([:]) // unread state is per-server; drop it too
         preferences.saveGroupingMode(.default) // reset the list grouping pref on logout
         preferences.saveDefaultSessionSwipeAction(.default) // reset the swipe-action pref too
+        preferences.saveShowCronSection(true) // reset the cron-section visibility pref too
         preferences.clearSelectedProfileID() // selected profile is per-server — clear on logout
         chatSnapshot.wipeAll() // snapshots + turn anchors are per-server — wipe on logout
         return .merge(

--- a/HermesKit/Tests/HermesKitTests/PreferencesClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/PreferencesClientTests.swift
@@ -110,6 +110,28 @@ struct PreferencesClientTests {
     #expect(prefs.loadDefaultSessionSwipeAction() == .archive) // unknown raw value → default
   }
 
+  @Test func inMemoryShowCronSectionRoundTripAndDefault() {
+    let prefs = PreferencesClient.inMemory()
+    #expect(prefs.loadShowCronSection() == true) // default when unset: shown
+
+    prefs.saveShowCronSection(false)
+    #expect(prefs.loadShowCronSection() == false)
+
+    prefs.saveShowCronSection(true)
+    #expect(prefs.loadShowCronSection() == true)
+  }
+
+  @Test func liveShowCronSectionBacksOntoProvidedDefaults() {
+    let suite = UserDefaults(suiteName: "hermes.prefs.test.showcron")!
+    suite.removePersistentDomain(forName: "hermes.prefs.test.showcron")
+    let prefs = PreferencesClient.live(defaults: suite)
+
+    #expect(prefs.loadShowCronSection() == true) // default when unset: shown
+    prefs.saveShowCronSection(false)
+    #expect(suite.bool(forKey: "hermes.show-cron-section") == false)
+    #expect(prefs.loadShowCronSection() == false)
+  }
+
   @Test func inMemorySelectedProfileRoundTripAndClear() {
     let prefs = PreferencesClient.inMemory()
     #expect(prefs.loadSelectedProfileID() == nil)

--- a/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
@@ -2263,6 +2263,56 @@ struct SessionListFeatureTests {
     await store.send(.onDisappear)
   }
 
+  // MARK: - Cron section visibility
+
+  @Test func setShowCronSectionUpdatesStateAndPersists() async {
+    let prefs = PreferencesClient.inMemory()
+    let store = TestStore(initialState: SessionListFeature.State(connection: connection)) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.preferences = prefs
+    }
+
+    #expect(store.state.showCronSection == true) // default: shown
+    await store.send(.setShowCronSection(false)) {
+      $0.showCronSection = false
+    }
+    #expect(prefs.loadShowCronSection() == false) // persisted
+
+    // Re-sending the same value is a no-op (no state change).
+    await store.send(.setShowCronSection(false))
+  }
+
+  @Test func loadSeedsShowCronSectionFromPreferences() async {
+    let prefs = PreferencesClient.inMemory()
+    prefs.saveShowCronSection(false)
+    let store = TestStore(initialState: SessionListFeature.State(connection: connection)) {
+      SessionListFeature()
+    } withDependencies: {
+      $0.date = .constant(now)
+      $0.continuousClock = TestClock()
+      $0.preferences = prefs
+      $0.hermesProfiles.list = { @Sendable _ in throw RESTError.notFound }
+      $0.hermesREST.pushPluginStatus = { @Sendable _ in .unknown }
+      $0.hermesREST.cronJobs = { @Sendable _, _ in throw RESTError.notFound }
+      $0.hermesREST.sessions = { @Sendable _, _, _, _ in [] }
+    }
+
+    await store.send(.task) {
+      $0.now = self.now
+      $0.isLoading = true
+      $0.showCronSection = false // seeded from prefs on load
+    }
+    await store.receive(\.setupPush)
+    await store.receive(\.pushPluginStatusLoaded)
+    await store.receive(\.profilesResponse.failure)
+    await store.receive(\.sessionsResponse.success) { $0.isLoading = false }
+    await store.receive(\.cronJobsResponse.failure) {
+      $0.cronJobsSupported = false
+    }
+    await store.send(.onDisappear)
+  }
+
   @Test func chronologicalSessionsAreRecencyOrderedAndExcludePinned() {
     var state = SessionListFeature.State(connection: connection)
     state.sessions = [

--- a/HermesKit/Tests/HermesKitTests/SettingsFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SettingsFeatureTests.swift
@@ -34,6 +34,7 @@ struct SettingsFeatureTests {
     #expect(preferences.loadSeenCounts() == [:]) // unread state cleared too
     #expect(preferences.loadGroupingMode() == .workspace) // grouping pref reset on logout
     #expect(preferences.loadDefaultSessionSwipeAction() == .archive) // swipe pref reset on logout
+    #expect(preferences.loadShowCronSection() == true) // cron-section visibility reset on logout
     #expect(preferences.loadSelectedProfileID() == nil) // selected profile cleared on logout
   }
 

--- a/HermesMobile/Sources/Features/SessionListView.swift
+++ b/HermesMobile/Sources/Features/SessionListView.swift
@@ -157,8 +157,9 @@ struct SessionListView: View {
     }
     // Cron-scheduled sessions live in their own always-on section below the
     // interactive list, in both grouping modes (filtered out of pinned/groups/
-    // chronological by the reducer). Hidden when there are none.
-    if !store.cronSessions.isEmpty {
+    // chronological by the reducer). Hidden when there are none, or when the
+    // user turned the section off in the organize menu.
+    if store.showCronSection, !store.cronSessions.isEmpty {
       cronJobsSection
     }
   }
@@ -432,6 +433,15 @@ struct SessionListView: View {
         Label("Chronological", systemImage: "clock").tag(SessionGroupingMode.chronological)
       }
       .pickerStyle(.inline)
+
+      Divider()
+
+      Toggle(isOn: Binding(
+        get: { store.showCronSection },
+        set: { store.send(.setShowCronSection($0)) }
+      )) {
+        Label("Cron Jobs section", systemImage: "clock")
+      }
 
       Divider()
 


### PR DESCRIPTION
## What

Adds a device-local **"Cron Jobs section"** toggle to the organize menu (top-right), so users who want a chat-only session list can hide the always-on cron section.

## Why

The Cron Jobs section is currently always-on whenever cron sessions exist. Some users (myself included) want the main view to stay minimal — just sessions and chat — while still having cron jobs running on the agent. This makes the section opt-out without touching any cron data fetching.

## Changes

- **PreferencesClient**: `loadShowCronSection` / `saveShowCronSection` — UserDefaults key `hermes.show-cron-section`; absent key means shown (on by default, no behavior change for existing users).
- **SessionListFeature**: `showCronSection` state (default `true`), `setShowCronSection(Bool)` action (no-op guard like `setGroupingMode`), seeded in `reloadPrefs`.
- **SessionListView**: `cronJobsSection` gated on `showCronSection`; toggle added to the organize menu between Grouping and Archived sessions.
- **Tests**: reducer + persistence coverage in `SessionListFeatureTests` and `PreferencesClientTests`, mirroring the existing grouping-mode test patterns.

## Notes

- Follows the exact pattern of the existing `groupingMode` pref (device-local, seeded on `.task`, persisted immediately).
- No changes to cron fetching, unread badges, or the search-mode behavior (search already hides the cron section).
- I don't have Xcode on this machine, so I couldn't compile/run the test suite locally — the change is small and mirrors existing patterns, but please verify on your side.