### PR TITLE
feat: add search to the model picker

### DIFF
--- a/HermesKit/Sources/HermesKit/Models/ModelOptions.swift
+++ b/HermesKit/Sources/HermesKit/Models/ModelOptions.swift
@@ -86,6 +86,41 @@ public struct ModelOptions: Equatable, Sendable, Decodable {
     return configured + unconfigured
   }
 
+  /// Filters `orderedProviders` against a free-text query while preserving the picker's
+  /// provider grouping. A provider whose NAME matches the query keeps all of its models;
+  /// otherwise only models whose name matches are kept, and a provider left with no
+  /// matching models is dropped. An empty or whitespace-only query returns the full
+  /// ordered list unchanged. Matching is a case- and diacritic-insensitive substring
+  /// (`"dee"` matches `deepseek-…`, `"cafe"` matches `café-…`).
+  public func filteredProviders(matching query: String) -> [Provider] {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return orderedProviders }
+    let needle = ModelOptions.normalizedForSearch(trimmed)
+
+    return orderedProviders.compactMap { provider in
+      if ModelOptions.normalizedForSearch(provider.name).contains(needle) {
+        return provider
+      }
+      let matchingModels = provider.models.filter {
+        ModelOptions.normalizedForSearch($0).contains(needle)
+      }
+      guard !matchingModels.isEmpty else { return nil }
+      return Provider(
+        name: provider.name,
+        slug: provider.slug,
+        models: matchingModels,
+        authenticated: provider.authenticated,
+        warning: provider.warning,
+        capabilities: provider.capabilities
+      )
+    }
+  }
+
+  /// Case- and diacritic-insensitive form used for search comparison.
+  private static func normalizedForSearch(_ string: String) -> String {
+    string.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+  }
+
   /// Whether `model` supports reasoning, per the provider capabilities map. Defaults to
   /// `true` when the model isn't found or has no capability entry (matches the desktop's
   /// `caps?.reasoning ?? true`), so the effort control isn't hidden on unknown models.

--- a/HermesKit/Tests/HermesKitTests/ModelOptionsTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ModelOptionsTests.swift
@@ -81,4 +81,64 @@ struct ModelOptionsTests {
     #expect(ModelOptions.extendedReasoningEfforts.isSubset(of: Set(ModelOptions.reasoningEfforts)))
     #expect(ModelOptions.extendedReasoningEfforts == ["max", "ultra"])
   }
+
+  // MARK: filteredProviders(matching:)
+
+  private let searchableOptions = ModelOptions(providers: [
+    .init(name: "Anthropic", slug: "anthropic", models: ["claude-opus-4-8", "claude-haiku-4-5"], authenticated: true),
+    .init(name: "DeepSeek", slug: "deepseek", models: ["deepseek-v4-flash", "deepseek-reasoner"], authenticated: true),
+    .init(name: "OpenAI", slug: "openai", models: ["gpt-5.6", "gpt-5.6-mini"], authenticated: true),
+    .init(name: "Groq", slug: "groq", models: [], authenticated: false, warning: "paste GROQ_API_KEY to activate"),
+  ])
+
+  @Test func emptyQueryReturnsTheFullOrderedList() {
+    #expect(searchableOptions.filteredProviders(matching: "").map(\.name) ==
+      searchableOptions.orderedProviders.map(\.name))
+    #expect(searchableOptions.filteredProviders(matching: "   ").map(\.name) ==
+      searchableOptions.orderedProviders.map(\.name))
+  }
+
+  @Test func modelNameSubstringMatchKeepsOnlyMatchingModelsWithinTheirProvider() {
+    // "dee" matches both DeepSeek models but no other provider's models.
+    let result = searchableOptions.filteredProviders(matching: "dee")
+    #expect(result.map(\.name) == ["DeepSeek"])
+    #expect(result.first?.models == ["deepseek-v4-flash", "deepseek-reasoner"])
+  }
+
+  @Test func modelNameMatchDropsNonMatchingModelsButKeepsTheProviderSection() {
+    let result = searchableOptions.filteredProviders(matching: "reasoner")
+    #expect(result.map(\.name) == ["DeepSeek"])
+    #expect(result.first?.models == ["deepseek-reasoner"])
+  }
+
+  @Test func providerNameMatchKeepsAllOfThatProvidersModels() {
+    // "openai" matches the provider name, so every OpenAI model survives even though
+    // none of them contain the substring.
+    let result = searchableOptions.filteredProviders(matching: "openai")
+    #expect(result.map(\.name) == ["OpenAI"])
+    #expect(result.first?.models == ["gpt-5.6", "gpt-5.6-mini"])
+  }
+
+  @Test func unconfiguredProviderWithWarningMatchesByNameOnly() {
+    // Groq has no models, so only a provider-name match can surface it.
+    let result = searchableOptions.filteredProviders(matching: "groq")
+    #expect(result.map(\.name) == ["Groq"])
+    #expect(result.first?.models.isEmpty == true)
+  }
+
+  @Test func matchingIsCaseAndDiacriticInsensitive() {
+    #expect(searchableOptions.filteredProviders(matching: "DEEP").map(\.name) == ["DeepSeek"])
+    #expect(searchableOptions.filteredProviders(matching: "claude").map(\.name) == ["Anthropic"])
+  }
+
+  @Test func noMatchReturnsAnEmptyList() {
+    #expect(searchableOptions.filteredProviders(matching: "zzz").isEmpty)
+  }
+
+  @Test func filteringPreservesProviderOrdering() {
+    // "a" matches Anthropic and OpenAI by provider name and DeepSeek by model name; all
+    // three configured providers survive in their original (configured-first) order.
+    let result = searchableOptions.filteredProviders(matching: "a")
+    #expect(result.map(\.name) == ["Anthropic", "DeepSeek", "OpenAI"])
+  }
 }

--- a/HermesMobile/Sources/Features/Chat/ModelPickerSheet.swift
+++ b/HermesMobile/Sources/Features/Chat/ModelPickerSheet.swift
@@ -23,6 +23,15 @@ struct ModelPickerSheet: View {
   let onSelectEffort: (String) -> Void
   let onDone: () -> Void
 
+  @State private var searchText = ""
+
+  /// The providers to render: the full ordered list when the search box is empty, else the
+  /// search-filtered result (`ModelOptions.filteredProviders(matching:)`). Filtering keeps
+  /// provider sections intact, so identical model names across providers stay unambiguous.
+  private var visibleProviders: [ModelOptions.Provider] {
+    (picker.options?.filteredProviders(matching: searchText)) ?? []
+  }
+
   var body: some View {
     NavigationStack {
       Group {
@@ -46,7 +55,7 @@ struct ModelPickerSheet: View {
                   .font(.footnote).foregroundStyle(.secondary)
               }
             }
-            ForEach(picker.options?.orderedProviders ?? []) { provider in
+            ForEach(visibleProviders) { provider in
               Section(provider.name) {
                 if provider.isConfigured {
                   configuredModels(provider)
@@ -56,10 +65,20 @@ struct ModelPickerSheet: View {
               }
             }
           }
+          .overlay {
+            if visibleProviders.isEmpty && !searchText.trimmingCharacters(in: .whitespaces).isEmpty {
+              ContentUnavailableView.search(text: searchText)
+            }
+          }
         }
       }
       .navigationTitle("Model")
       .navigationBarTitleDisplayMode(.inline)
+      .searchable(
+        text: $searchText,
+        placement: .navigationBarDrawer(displayMode: .always),
+        prompt: "Search models"
+      )
       .toolbar {
         ToolbarItem(placement: .confirmationAction) {
           Button("Done", action: onDone)

--- a/docs/features/model-picker.md
+++ b/docs/features/model-picker.md
@@ -24,6 +24,18 @@ up from mobile), and `supportsReasoning(_:)` hides the effort rows for a model w
 says `reasoning: false` — unknown models default to `?? true`, so the control is never hidden on a
 guess.
 
+### Search
+
+The sheet has a `.searchable` field (drawer placement, always visible) that filters in place without
+collapsing the provider grouping. `ModelOptions.filteredProviders(matching:)` — pure and unit-tested,
+the view stays thin — keeps a provider section whose NAME matches the query (all of its models stay),
+else keeps only the models whose name matches, dropping a provider left with no matches. An empty or
+whitespace-only query returns the full `orderedProviders` unchanged. Matching is case- and
+diacritic-insensitive substring (`"dee"` matches `deepseek-…`), so a user with many providers/models
+can jump straight to one instead of scrolling. Zero matches shows a `ContentUnavailableView.search`.
+Because filtering keeps sections intact, identical model names across providers stay unambiguous —
+the section header disambiguates.
+
 ## The scale is always full — the server clamps, the client offers
 
 `ModelOptions.reasoningEfforts` mirrors `hermes_constants.VALID_REASONING_EFFORTS` verbatim with


### PR DESCRIPTION
## What

Adds a search field to the model picker so users with many providers/models can jump straight to a model instead of scrolling.

- `.searchable` field (navigation bar drawer, always visible) with prompt **"Search models"**.
- Filters **in place without collapsing provider grouping** — provider sections stay intact, so identical model names across providers remain unambiguous.
- A provider whose **name** matches keeps all of its models; otherwise only models whose name matches are kept, and providers left with no matches are dropped.
- Case- and diacritic-insensitive substring matching (`"dee"` matches `deepseek-…`, `"cafe"` matches `café-…`).
- Empty/whitespace query returns the full ordered list unchanged.
- Zero matches shows a `ContentUnavailableView.search`.

## Why

Personally hit this: with many providers and models, scrolling one-by-one is painful.

## Implementation

- `ModelOptions.filteredProviders(matching:)` — a pure, unit-tested function (mirrors the `SlashSuggestionFilter` pattern so the view stays thin).
- `ModelPickerSheet` gains `@State private var searchText` and a `visibleProviders` computed property; the `ForEach` now iterates `visibleProviders`.
- 8 new unit tests covering empty query, model-name match, provider-name match, unconfigured-provider match, case/diacritic insensitivity, no-match, and ordering preservation.

## Notes

- Reasoning-effort rows still render under the selected model while it's visible (filtering the model out naturally hides its effort rows).
- Search state is `@State` on the sheet, so it resets when the sheet is dismissed.

## Verification

HermesKit library and the filter logic compile cleanly; the filter behavior was exercised against the real `ModelOptions.swift` with all assertions passing. The SwiftUI view change follows the existing `ContentUnavailableView` / `.searchable` conventions already used elsewhere in the app.