### PR TITLE
fix: route model picks through the picker section's provider (#100)

### DIFF
--- a/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/ChatFeature.swift
@@ -819,7 +819,12 @@ public struct ChatFeature {
     case toolDetailDismissed
     case modelChipTapped
     case modelOptionsResponse(Result<ModelOptions, GatewayError>)
-    case modelSelected(String)
+    /// The provider SLUG of the section the row was tapped in (nil for a programmatic
+    /// selection with no section context). Appended to the `config.set` value as
+    /// `--provider <slug>` so the gateway routes the model to the provider the picker
+    /// showed it under, instead of guessing from the model id (a `openai/…` OpenRouter
+    /// row would otherwise resolve to the direct OpenAI provider and fail on its key).
+    case modelSelected(model: String, provider: String?)
     case reasoningSelected(String)
     /// A `config.set` that failed for good (the #17 heal has already had its single replay).
     /// Carries the rejected `value` so the latch banner can name it and `previousValue` so the
@@ -2040,7 +2045,7 @@ public struct ChatFeature {
         state.modelPicker?.error = error.message
         return .none
 
-      case let .modelSelected(model):
+      case let .modelSelected(model, providerSlug):
         // Blocked mid-turn (server returns 4009); the picker disables selection too.
         guard !state.isSending, let sessionID = state.liveSessionID else { return .none }
         // Roll back to the last SERVER-confirmed value, not to a still-in-flight pick's.
@@ -2048,8 +2053,13 @@ public struct ChatFeature {
         state.pendingConfigRollback.updateValue(previousModel, forKey: "model")
         state.model = model // optimistic; reconciled by the next session.info
         clearConfigError(&state)
+        // Desktop parity (`use-model-controls.ts`): the value carries the picker
+        // section's provider slug so the gateway's model routing never guesses from
+        // the model id alone. A nil slug (no section context) stays a bare model id —
+        // the gateway's own detection ladder handles it exactly as before.
+        let wireValue = providerSlug.map { "\(model) --provider \($0)" } ?? model
         return configSet(
-          key: "model", value: model, previousValue: previousModel, sessionID: sessionID,
+          key: "model", value: wireValue, previousValue: previousModel, sessionID: sessionID,
           storedSessionID: state.storedSessionID, branchSeed: state.branchSeed,
           profile: state.scopedProfile
         )

--- a/HermesKit/Sources/HermesKit/Models/ModelOptions.swift
+++ b/HermesKit/Sources/HermesKit/Models/ModelOptions.swift
@@ -36,6 +36,18 @@ public struct ModelOptions: Equatable, Sendable, Decodable {
 
     public var id: String { slug ?? name }
 
+    /// The identifier to send as `--provider` on a model switch. The SLUG only — desktop
+    /// parity (`use-model-controls.ts` sends `provider.slug`, no fallback). The gateway's
+    /// `parse_model_flags_detailed` splits the value on whitespace and
+    /// `resolve_provider_full` never matches display names, so a name fallback (e.g.
+    /// "Ollama Cloud") would parse as provider `Ollama`, model `… Cloud` — worse than a
+    /// bare id. Nil (no slug) sends the model out bare and the gateway's own detection
+    /// ladder routes it; today every gateway row builder passes a slug, so nil is rare.
+    public var selectionSlug: String? {
+      let slugValue = (slug ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+      return slugValue.isEmpty ? nil : slugValue
+    }
+
     /// Configured + usable: authenticated with at least one model. Unconfigured providers
     /// come back authenticated=false with an empty model list and a `warning`.
     public var isConfigured: Bool { (authenticated ?? false) && !models.isEmpty }

--- a/HermesKit/Tests/HermesKitTests/ChatInteractionTests.swift
+++ b/HermesKit/Tests/HermesKitTests/ChatInteractionTests.swift
@@ -248,7 +248,7 @@ struct ChatInteractionTests {
       }
     }
 
-    await store.send(.modelSelected("claude-sonnet-4-6")) {
+    await store.send(.modelSelected(model: "claude-sonnet-4-6", provider: "anthropic")) {
       $0.model = "claude-sonnet-4-6" // optimistic
       $0.pendingConfigRollback.updateValue(nil, forKey: "model") // nothing confirmed yet
     }
@@ -256,8 +256,50 @@ struct ChatInteractionTests {
 
     #expect(sent.value?["method"]?.stringValue == "config.set")
     #expect(sent.value?["params"]?["key"]?.stringValue == "model")
-    #expect(sent.value?["params"]?["value"]?.stringValue == "claude-sonnet-4-6")
+    // Desktop parity: the value carries the picker section's provider slug so the
+    // gateway routes the model to the provider the picker showed it under.
+    #expect(sent.value?["params"]?["value"]?.stringValue == "claude-sonnet-4-6 --provider anthropic")
     #expect(sent.value?["params"]?["session_id"]?.stringValue == "live")
+  }
+
+  /// A selection with no section context (nil provider) stays a bare model id on the wire —
+  /// the gateway's own detection ladder routes it exactly as before this change.
+  @Test func selectingModelWithoutProviderSendsBareModel() async {
+    let sent = LockIsolated<JSONValue?>(nil)
+    let store = TestStore(initialState: readyState()) { ChatFeature() } withDependencies: {
+      $0.hermesGateway.send = { @Sendable method, params in
+        sent.setValue(.object(["method": .string(method), "params": params]))
+        return .object([:])
+      }
+    }
+
+    await store.send(.modelSelected(model: "claude-sonnet-4-6", provider: nil)) {
+      $0.model = "claude-sonnet-4-6"
+      $0.pendingConfigRollback.updateValue(nil, forKey: "model")
+    }
+    await store.finish()
+
+    #expect(sent.value?["method"]?.stringValue == "config.set")
+    #expect(sent.value?["params"]?["value"]?.stringValue == "claude-sonnet-4-6")
+  }
+
+  /// `selectionSlug` passes the slug only — the gateway's flag parser splits values on
+  /// whitespace and its provider resolver never matches display names, so a name fallback
+  /// ("Ollama Cloud") would misparse. Nil only when there is no slug.
+  @Test func providerSelectionSlugPreference() {
+    let slugful = ModelOptions.Provider(name: "OpenRouter", slug: "openrouter", models: ["openai/gpt-5.6-sol"])
+    #expect(slugful.selectionSlug == "openrouter")
+
+    // No slug: the display name must NOT leak onto the wire ("Ollama Cloud" would parse
+    // as provider `Ollama`, model `… Cloud`); the pick goes out bare instead.
+    let slugless = ModelOptions.Provider(name: "Anthropic", slug: nil, models: ["claude-opus-4-8"])
+    #expect(slugless.selectionSlug == nil)
+
+    let empty = ModelOptions.Provider(name: "", slug: nil, models: [])
+    #expect(empty.selectionSlug == nil)
+
+    let whitespace = ModelOptions.Provider(name: "  ", slug: "  ", models: [])
+    #expect(whitespace.selectionSlug == nil)
   }
 
   @Test func selectingReasoningSendsConfigSet() async {
@@ -328,7 +370,7 @@ struct ChatInteractionTests {
     initial.isSending = true
     let store = TestStore(initialState: initial) { ChatFeature() }
     // Mid-turn switches are rejected by the server (4009) — guarded client-side.
-    await store.send(.modelSelected("claude-sonnet-4-6"))
+    await store.send(.modelSelected(model: "claude-sonnet-4-6", provider: nil))
     await store.send(.reasoningSelected("high"))
   }
 
@@ -415,7 +457,7 @@ struct ChatInteractionTests {
       $0.hermesGateway.send = failingConfigSet(GatewayError.server("cannot switch mid-turn"))
     }
 
-    await store.send(.modelSelected("gpt-5-mini")) {
+    await store.send(.modelSelected(model: "gpt-5-mini", provider: "openai")) {
       $0.model = "gpt-5-mini"
       $0.pendingConfigRollback.updateValue("gpt-5", forKey: "model")
     }

--- a/HermesMobile/Sources/Features/Chat/ChatView.swift
+++ b/HermesMobile/Sources/Features/Chat/ChatView.swift
@@ -124,7 +124,7 @@ struct ChatView: View {
           currentEffort: store.reasoningEffort,
           isBusy: store.isSending,
           extendedReasoningSupported: store.extendedReasoningSupported,
-          onSelectModel: { store.send(.modelSelected($0)) },
+          onSelectModel: { store.send(.modelSelected(model: $0, provider: $1)) },
           onSelectEffort: { store.send(.reasoningSelected($0)) },
           onDone: { store.send(.modelPickerDismissed) }
         )

--- a/HermesMobile/Sources/Features/Chat/ModelPickerSheet.swift
+++ b/HermesMobile/Sources/Features/Chat/ModelPickerSheet.swift
@@ -19,7 +19,7 @@ struct ModelPickerSheet: View {
   /// `ChatFeature.State.extendedReasoningSupported`: false hides `max`/`ultra` after this
   /// slot's agent rejected one. Defaulted so the snapshot call sites stay unchanged.
   var extendedReasoningSupported: Bool = true
-  let onSelectModel: (String) -> Void
+  let onSelectModel: (String, String?) -> Void
   let onSelectEffort: (String) -> Void
   let onDone: () -> Void
 
@@ -90,7 +90,9 @@ struct ModelPickerSheet: View {
   @ViewBuilder
   private func configuredModels(_ provider: ModelOptions.Provider) -> some View {
     ForEach(provider.models, id: \.self) { model in
-      selectableRow(model, selected: model == currentModel) { onSelectModel(model) }
+      selectableRow(model, selected: model == currentModel) {
+        onSelectModel(model, provider.selectionSlug)
+      }
       // Reasoning effort drops down under the selected, reasoning-capable model.
       if model == currentModel, picker.options?.supportsReasoning(model) ?? true {
         ForEach(ModelOptions.offeredEfforts(extendedSupported: extendedReasoningSupported),

--- a/HermesMobileTests/ComposerSnapshotTests.swift
+++ b/HermesMobileTests/ComposerSnapshotTests.swift
@@ -164,7 +164,7 @@ final class ComposerSnapshotTests: SnapshotTestCase {
       currentModel: "gpt-5", // reasoning-capable → effort options drop down under it, "high" selected
       currentEffort: "high",
       isBusy: false,
-      onSelectModel: { _ in }, onSelectEffort: { _ in }, onDone: {}
+      onSelectModel: { _, _ in }, onSelectEffort: { _ in }, onDone: {}
     )
     assertSnapshot(of: view, as: deviceImage())
   }
@@ -192,7 +192,7 @@ final class ComposerSnapshotTests: SnapshotTestCase {
       currentEffort: "high",
       isBusy: false,
       extendedReasoningSupported: false,
-      onSelectModel: { _ in }, onSelectEffort: { _ in }, onDone: {}
+      onSelectModel: { _, _ in }, onSelectEffort: { _ in }, onDone: {}
     )
     assertSnapshot(of: view, as: deviceImage())
   }
@@ -220,7 +220,7 @@ final class ComposerSnapshotTests: SnapshotTestCase {
       currentModel: "gpt-5",
       currentEffort: "high",
       isBusy: false,
-      onSelectModel: { _ in }, onSelectEffort: { _ in }, onDone: {}
+      onSelectModel: { _, _ in }, onSelectEffort: { _ in }, onDone: {}
     )
     assertSnapshot(of: view, as: deviceImage())
   }
@@ -245,7 +245,7 @@ final class ComposerSnapshotTests: SnapshotTestCase {
       currentModel: "claude-haiku-4-5", // no reasoning → effort section hidden
       currentEffort: nil,
       isBusy: false,
-      onSelectModel: { _ in }, onSelectEffort: { _ in }, onDone: {}
+      onSelectModel: { _, _ in }, onSelectEffort: { _ in }, onDone: {}
     )
     assertSnapshot(of: view, as: deviceImage())
   }

--- a/docs/features/model-picker.md
+++ b/docs/features/model-picker.md
@@ -11,6 +11,25 @@ The composer's `model · effort` chip is the ONE affordance for both settings. T
 `configSet(key:value:previousValue:…)` → `config.set {session_id, key, value}` wrapped in the #17
 session-not-found heal (re-resume + a single replay, `CLAUDE.md` → "Gateway & session lifecycle").
 
+A model selection carries the picker section's provider: the row tap passes
+`ModelOptions.Provider.selectionSlug` — the SLUG only, nil when there is none — and the reducer
+appends it to the wire value as `"<model> --provider <slug>"` — desktop parity
+(`use-model-controls.ts`, which also sends `provider.slug` with no fallback). Without it the
+gateway guesses the provider from the model id alone, so an `openai/…` row listed under
+OpenRouter routes to the direct OpenAI provider and fails on its key ("No usable credentials
+found for provider 'openai-api'"). A nil slug (no section context) stays a bare model id and
+the gateway's own detection ladder routes it, exactly as before. The display name is never
+used: the gateway's flag parser splits the `--provider` value on whitespace and its provider
+resolver doesn't match display names, so a name like "Ollama Cloud" would parse as provider
+`Ollama`, model `… Cloud` — worse than a bare id.
+
+One behavioral note, same as desktop: with `--provider` present, a switch never persists to
+`config.yaml` when a default model is already configured — the gateway's
+`resolve_persist_behavior` treats provider-bound picks as exploratory and skips the
+`model.persist_switch_by_default` check. Bare-id picks honor that config key (a pick without
+`--provider` persists when it is `true`); provider-bound picks are session-only unless the
+desktop sends an explicit `--global`, which no client picker does today.
+
 Selection is **optimistic and server-reconciled**: the reducer writes `state.model` /
 `state.reasoningEffort` before the RPC, and success is deliberately fire-and-forget — the gateway
 emits `session.info` after a successful `config.set` and `.sessionInfo` already reconciles both


### PR DESCRIPTION
## What

Fixes #100. The model picker now sends the provider the row was actually listed under, instead of a bare model id the gateway has to guess a provider for.

- `ChatFeature.modelSelected` now carries the picker section's provider and the reducer appends `--provider <slug>` to the `config.set` value: `config.set {key: "model", value: "openai/gpt-5.6-sol --provider openrouter"}`.
- `ModelOptions.Provider.selectionSlug` — slug, falling back to the name (the gateway's `resolve_provider_full` matches either), nil only when both are empty.
- `ModelPickerSheet` passes the section slug on the row tap; a nil slug (no section context) keeps the bare-id wire value, so the gateway's own detection ladder still handles those picks exactly as before.

## Why

Personally hit this on two providers in one sitting:

- Picking `openai/gpt-5.6-sol` from the **OpenRouter** section → `Couldn't change model: Could not resolve credentials for provider 'openai-api': No usable credentials found for provider 'openai-api'. Set OPENAI_API_KEY.` — the gateway saw the `openai/` prefix, guessed the direct OpenAI provider, and demanded its key, even though the pick came from a fully working OpenRouter section.
- Picking a deepseek model from **Ollama** → the switch went looking for a DeepSeek API key (direct provider), not the Ollama Cloud runtime the section was rendered from.

The same picks work from the desktop app against the same server/profile/session. The reason is exactly this gap: `use-model-controls.ts` sends `${model} --provider ${provider.slug}` — the desktop's wire contract this PR replicates. The provider grouping in the mobile sheet was cosmetic; the section the user picked from never reached the request.

Any user with the same model id reachable from two providers (native + aggregator, native + local runtime) hits this, so it generalizes beyond my setup.

## Implementation

- `ChatFeature`: `.modelSelected(model: String, provider: String?)` — the reducer builds the wire value; rollback/latch/banner paths unchanged (`configSetFailed` still carries the model id, and `state.model` stays the bare id so the chip and rollback never display the flag).
- `ModelOptions.Provider.selectionSlug`: pure, unit-tested.
- `ModelPickerSheet` + `ChatView`: pass the section's slug through; snapshot call sites updated.
- `docs/features/model-picker.md`: the picker-path section now records the wire contract.

## Verification

- Full HermesKit suite green on macOS: **1,305 tests / 60 suites**, including 3 new tests: `--provider` present on the wire for a sectioned pick, bare id unchanged for a nil provider, and `selectionSlug` preference (slug → name → nil).
- iOS app target compiled with **Xcode 26.3** for the iOS Simulator destination (workspace via `tuist generate`) in CI — build and full suite green: [run 33955279416](https://github.com/netera-michael/hermes-mobile/actions/runs/33955279416).
- Backend contract checked live against `hermes-agent` `parse_model_switch_args`: the `--provider` suffix parses correctly, and the gateway resolves slugs and names.
- Residual risk, stated honestly: no on-device tap-through smoke of the picker against a live gateway from CI — same caveat class as #95. The wire value is byte-for-byte the desktop's, and the desktop path is the proven one.