### PR TITLE
Sync session unread state across clients

### DIFF
--- a/HermesKit/Sources/HermesKit/AppFeature.swift
+++ b/HermesKit/Sources/HermesKit/AppFeature.swift
@@ -513,6 +513,12 @@ public struct AppFeature {
           if expectsApproval {
             state.liveChat?.expectsPendingApproval = true
           }
+          let read = acknowledgeRead(
+            &state,
+            sessionID: session.id,
+            connection: chat.connection,
+            profileName: chat.profileName
+          )
           // Marker only when the chat is actually detached (compact + empty path) — in
           // regular the slot is already the visible detail and the path stays empty.
           // Defensive guard too: the path is normally empty here in compact (re-opens come
@@ -522,26 +528,33 @@ public struct AppFeature {
           if state.isChatDetached {
             state.path.append(ChatScreen.State(sessionKey: session.id))
           }
-          return .merge(badge, .send(.liveChat(.reattached)))
+          return .merge(badge, read, .send(.liveChat(.reattached)))
         }
         // `resolvedTitle` keeps the server's "Untitled" placeholder out of the header
         // (and the rename pre-fill); a real title arrives via `session.info` on resume.
         // Carry the active profile so resume/history scope to the right `state.db`.
+        let profileName = home.scopedProfileName
         var chat = ChatFeature.State(
           connection: home.connection,
           resumeStoredID: session.id,
-          profileName: home.scopedProfileName,
+          profileName: profileName,
           title: session.resolvedTitle
+        )
+        let read = acknowledgeRead(
+          &state,
+          sessionID: session.id,
+          connection: home.connection,
+          profileName: profileName
         )
         chat.expectsPendingApproval = expectsApproval
         guard state.liveChat != nil else {
           seatLiveChat(chat, into: &state)
-          return badge
+          return .merge(badge, read)
         }
         // Slot occupied (e.g. a push tap while a chat is open): replace it — the old chat
         // must be fully torn down (through the nil-out, so even its un-ID'd one-shot RPC
         // effects are cancelled) before the new chat fills the slot.
-        return .merge(badge, teardownSlot(thenFill: chat))
+        return .merge(badge, read, teardownSlot(thenFill: chat))
 
       case let .home(.delegate(.createSession(initialComposerText))):
         guard let home = state.home else { return .none }
@@ -793,9 +806,32 @@ public struct AppFeature {
         // Route the live chat's authoritative working-state change to the session list so its
         // row glow clears/lights INSTANTLY (event-driven), without waiting for the next poll.
         // The poll stays the backstop for not-open sessions. No `home` → nothing to patch.
-        let glow: Effect<Action> = state.home != nil
+        let canPatchVisibleRow: Bool
+        if let home = state.home, let chat = state.liveChat {
+          canPatchVisibleRow = home.scopedProfileName == chat.profileName
+        } else {
+          canPatchVisibleRow = false
+        }
+        let glow: Effect<Action> = canPatchVisibleRow
           ? .send(.home(.setSessionRunning(id: sessionID, running: running)))
           : .none
+        // A completion that lands while this chat is on screen has already been seen. Advance
+        // the shared backend watermark after the new activity, not just when the row was first
+        // opened before the turn, so Desktop does not rediscover it as unread on its next poll.
+        let read: Effect<Action>
+        if !running,
+          state.currentViewingSessionID == sessionID,
+          let chat = state.liveChat {
+          read = acknowledgeRead(
+            &state,
+            sessionID: sessionID,
+            connection: chat.connection,
+            profileName: chat.profileName
+          )
+        } else {
+          read = .none
+        }
+        let listUpdate: Effect<Action> = .concatenate(glow, read)
         // A DETACHED slot (`isChatDetached`: compact with no marker in the path — the user
         // popped to the list; never the case in regular, where the slot is the visible
         // detail column) only outlives the pop while its turn runs. The turn ending —
@@ -810,8 +846,8 @@ public struct AppFeature {
         // a queue parked by an error while detached deliberately keeps the slot (bounded
         // by the user re-opening or archiving the session).
         guard !running, state.isChatDetached, let chat = state.liveChat, !chat.hasQueuedWork
-        else { return glow }
-        return .concatenate(glow, teardownSlot())
+        else { return listUpdate }
+        return .concatenate(listUpdate, teardownSlot())
 
       case .onboarding, .connectionFailed, .home, .path, .reauth, .liveChat:
         return .none
@@ -890,6 +926,28 @@ public struct AppFeature {
     return .none
   }
 
+  /// Mark a session read under the profile that owns the active chat. Every open sends this
+  /// best-effort write—even when a cold-launch push has no loaded row—so a null server
+  /// watermark becomes tracked. Older agents reject/ignore the field and keep using the
+  /// local message-count fallback.
+  private func acknowledgeRead(
+    _ state: inout State,
+    sessionID: Session.ID,
+    connection: ServerConnection,
+    profileName: String?
+  ) -> Effect<Action> {
+    // Only mutate a visible row when the sidebar is showing the same profile. The active
+    // chat intentionally survives profile switches, so matching by id alone is unsafe.
+    if state.home?.scopedProfileName == profileName,
+       state.home?.sessions[id: sessionID]?.unread != nil
+    {
+      state.home?.sessions[id: sessionID]?.unread = false
+    }
+    return .run { [rest] _ in
+      try? await rest.setUnread(connection, sessionID, false, profileName)
+    }
+  }
+
   /// Deep-link a tapped push to its session — routed by comparing `tap.sessionID` against
   /// the live slot through `isChatDetached` (#32) so a tap for the already-open session
   /// never stacks a duplicate chat screen. Three outcomes, in order below: slot match + not
@@ -924,6 +982,17 @@ public struct AppFeature {
     // the existing `.foreground` re-hydrate.
     if state.currentViewingSessionID == tap.sessionID {
       state.pendingApprovalSessionIDs.remove(tap.sessionID)
+      let read: Effect<Action>
+      if let chat = state.liveChat {
+        read = acknowledgeRead(
+          &state,
+          sessionID: tap.sessionID,
+          connection: chat.connection,
+          profileName: chat.profileName
+        )
+      } else {
+        read = .none
+      }
       // Approval-recovery hint (#30 workaround): the socket may have been down when the
       // `approval.request` fired, so arm the one-shot hint AND drive the consuming
       // hydrate ourselves — the tap's scene activation is delivered independently of
@@ -933,9 +1002,9 @@ public struct AppFeature {
       // just re-hydrates. Nil slot guarded (the hint is meaningless without one).
       if tap.isApproval, state.liveChat != nil {
         state.liveChat?.expectsPendingApproval = true
-        return .merge(setBadge(state), .send(.liveChat(.foreground)))
+        return .merge(setBadge(state), read, .send(.liveChat(.foreground)))
       }
-      return setBadge(state)
+      return .merge(setBadge(state), read)
     }
     // Otherwise share the SAME `openSession` flow a list tap uses: a DETACHED slot match
     // (compact only — the user popped to the list; in regular a slot match always took

--- a/HermesKit/Sources/HermesKit/Clients/HermesRESTClient.swift
+++ b/HermesKit/Sources/HermesKit/Clients/HermesRESTClient.swift
@@ -207,6 +207,10 @@ public struct HermesRESTClient: Sendable {
   /// Pass `profile` (non-default) to scope to that profile (added to both query and body);
   /// `nil` → today's exact request.
   public var archive: @Sendable (_ connection: ServerConnection, _ id: String, _ archived: Bool, _ profile: String?) async throws -> Void
+  /// Set the shared unread flag — `PATCH /api/sessions/{id}` `{"unread":…}`. Sending
+  /// `false` on every open both acknowledges current activity and starts tracking a legacy
+  /// row whose server watermark is still nil. `profile` follows the archive/rename rule.
+  public var setUnread: @Sendable (_ connection: ServerConnection, _ id: String, _ unread: Bool, _ profile: String?) async throws -> Void
   /// Rename a session — `PATCH /api/sessions/{id}` `{"title":…}`. An empty title clears it.
   /// The server may reject with 400 (too long / invalid chars / duplicate).
   /// Pass `profile` (non-default) to scope to that profile (added to both query and body);
@@ -379,6 +383,14 @@ public extension HermesRESTClient {
         let body = try JSONSerialization.data(withJSONObject: payload)
         try await send(url, method: "PATCH", body: body, auth: authFor(conn), session: session)
       },
+      setUnread: { conn, id, unread, profile in
+        let query = profile.map { [URLQueryItem(name: "profile", value: $0)] } ?? []
+        let url = try makeURL(conn.baseURL, "/api/sessions/\(id)", query: query)
+        var payload: [String: Any] = ["unread": unread]
+        if let profile { payload["profile"] = profile }
+        let body = try JSONSerialization.data(withJSONObject: payload)
+        try await send(url, method: "PATCH", body: body, auth: authFor(conn), session: session)
+      },
       rename: { conn, id, title, profile in
         // Same endpoint/shape as `archive`: interpolate the RAW id (`makeURL` percent-encodes
         // the path), send `{"title": …}` — an empty string clears the title server-side.
@@ -493,8 +505,14 @@ public extension HermesRESTClient {
 
 extension HermesRESTClient: DependencyKey {
   public static var liveValue: HermesRESTClient { .live() }
-  // Unimplemented by default — REST calls in tests must be stubbed explicitly.
-  public static var testValue: HermesRESTClient { HermesRESTClient() }
+  // REST calls in tests are unimplemented unless explicitly stubbed. `setUnread` alone is a
+  // no-op default because reducers deliberately issue it as a best-effort compatibility write
+  // on every open; tests that verify shared-read behavior override it and assert the payload.
+  public static var testValue: HermesRESTClient {
+    var client = HermesRESTClient()
+    client.setUnread = { _, _, _, _ in }
+    return client
+  }
 }
 
 public extension DependencyValues {
@@ -824,6 +842,7 @@ struct SessionListDTO: Decodable {
   let lastActive: Double?
   let startedAt: Double?
   let messageCount: Int?
+  let unread: Bool?
   let cwd: String?
   let isActive: Bool?
   let source: String?
@@ -835,6 +854,7 @@ struct SessionListDTO: Decodable {
     case lastActive = "last_active"
     case startedAt = "started_at"
     case messageCount = "message_count"
+    case unread
     case isActive = "is_active"
     case parentSessionID = "parent_session_id"
     // Present only on compression-projected rows: the ORIGINAL id the row had before the
@@ -851,6 +871,7 @@ struct SessionListDTO: Decodable {
       cwd: cwd?.nonEmpty,
       startedAt: startedAt.map { Date(timeIntervalSince1970: $0) },
       messageCount: messageCount,
+      unread: unread,
       isActive: isActive,
       source: source,
       parentSessionID: parentSessionID?.trimmedNonEmpty,

--- a/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
+++ b/HermesKit/Sources/HermesKit/Features/SessionListFeature.swift
@@ -356,14 +356,18 @@ public struct SessionListFeature {
       flattenSessionsWithBranches(chronologicalSessions)
     }
 
-    /// Sessions with new activity since the user last opened them.
+    /// Sessions with new activity since the user last opened them. New agents own this
+    /// state server-side so Desktop and mobile agree; an absent field falls back to the
+    /// legacy device-local message-count watermark.
     public var unreadSessionIDs: Set<Session.ID> {
       Set(sessions.compactMap { session in
+        if let unread = session.unread { return unread ? session.id : nil }
         guard let count = session.messageCount, let seen = seenCounts[session.id], count > seen
         else { return nil }
         return session.id
       })
     }
+
 
     /// Rows to show for a group given its collapsed/expanded state.
     public func visibleSessions(in group: SessionGroup) -> [Session] {
@@ -869,10 +873,8 @@ public struct SessionListFeature {
 
       case let .sessionTapped(id):
         guard let session = state.sessions[id: id] else { return .none }
-        // Opening clears the unread flag (mark seen at the current count).
-        state.seenCounts[id] = session.messageCount ?? state.seenCounts[id] ?? 0
         return .merge(
-          persistSeenCounts(state.seenCounts),
+          markLocallyRead(id, state: &state),
           .send(.delegate(.openSession(session)))
         )
 
@@ -1579,6 +1581,17 @@ public struct SessionListFeature {
         await send(.cronJobActionFinished(id: id, refetchSessions: refetchSessions, error: .unreachable))
       }
     }
+  }
+
+  private func markLocallyRead(_ id: Session.ID, state: inout State) -> Effect<Action> {
+    guard let session = state.sessions[id: id] else { return .none }
+    // Preserve the legacy device watermark for older agents. The app-level common-open
+    // path owns the shared server acknowledgement so archived and push opens cannot bypass it.
+    state.seenCounts[id] = session.messageCount ?? state.seenCounts[id] ?? 0
+    if session.unread != nil {
+      state.sessions[id: id]?.unread = false
+    }
+    return persistSeenCounts(state.seenCounts)
   }
 
   private func persistSeenCounts(_ counts: [String: Int]) -> Effect<Action> {

--- a/HermesKit/Sources/HermesKit/Models/Session.swift
+++ b/HermesKit/Sources/HermesKit/Models/Session.swift
@@ -15,8 +15,13 @@ public struct Session: Equatable, Sendable, Identifiable {
   public var cwd: String?
   /// Original start time; used to order rows within a workspace group (desktop parity).
   public var startedAt: Date?
-  /// Number of messages — compared against the last-seen count to flag unread activity.
+  /// Number of messages — used only as the unread fallback for older agents that omit
+  /// the server-backed `unread` field.
   public var messageCount: Int?
+  /// Server-backed read state (`last_read_at` vs activity), shared by Desktop and every
+  /// mobile client. Nil means an older agent omitted the field; the list then falls back
+  /// to this device's message-count watermark.
+  public var unread: Bool?
   /// Whether the session is currently active (a turn ran recently).
   public var isActive: Bool?
   /// Where the session originated (`cron`, `cli`, `telegram`, `discord`, `slack`,
@@ -43,6 +48,7 @@ public struct Session: Equatable, Sendable, Identifiable {
     cwd: String? = nil,
     startedAt: Date? = nil,
     messageCount: Int? = nil,
+    unread: Bool? = nil,
     isActive: Bool? = nil,
     source: String? = nil,
     parentSessionID: String? = nil,
@@ -55,6 +61,7 @@ public struct Session: Equatable, Sendable, Identifiable {
     self.cwd = cwd
     self.startedAt = startedAt
     self.messageCount = messageCount
+    self.unread = unread
     self.isActive = isActive
     self.source = source
     self.parentSessionID = parentSessionID

--- a/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/AppFeatureTests.swift
@@ -1630,6 +1630,44 @@ struct AppFeatureTests {
     }
   }
 
+  @Test func visibleTurnCompletionUsesChatsOriginalProfileAfterSidebarSwitch() async {
+    let writes = LockIsolated<[(String, Bool, String?)]>([])
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection,
+          // This row belongs to the newly-selected profile and must not be mutated by
+          // completion of the still-visible chat from `work`.
+          sessions: [Session(id: "s1", messageCount: 4, unread: true, isActive: true)],
+          selectedProfileName: "personal",
+          profilesSupported: true
+        ),
+        path: StackState([ChatScreen.State(sessionKey: "s1")]),
+        liveChat: ChatFeature.State(
+          connection: connection,
+          resumeStoredID: "s1",
+          profileName: "work"
+        )
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.preferences = .inMemory()
+      $0.hermesREST.setUnread = { _, id, unread, profile in
+        writes.withValue { $0.append((id, unread, profile)) }
+      }
+    }
+
+    await store.send(.liveChat(.delegate(.runningChanged(sessionID: "s1", running: false))))
+    await store.finish()
+    #expect(store.state.home?.sessions[id: "s1"]?.isActive == true)
+    #expect(store.state.home?.sessions[id: "s1"]?.unread == true)
+    #expect(writes.value.count == 1)
+    #expect(writes.value.first?.0 == "s1")
+    #expect(writes.value.first?.1 == false)
+    #expect(writes.value.first?.2 == "work")
+  }
+
   // CRITICAL RULE: painting a chat from its cache must NEVER start a list glow on its own. The
   // list only ever lights a glow from a server-confirmed source (the delegate above, or a poll).
   // Painting a chat from its cache (`ChatFeature.State.init` reading the snapshot) does NOT push
@@ -2160,6 +2198,70 @@ struct AppFeatureTests {
   }
 
   // MARK: Push tap deep-link + foreground suppression + badge (C5)
+
+  @Test func archivedOpenAcknowledgesSharedReadStateInArchivedProfile() async {
+    let writes = LockIsolated<[(String, String?)]>([])
+    let archivedSession = Session(id: "archived", unread: false)
+    var home = SessionListFeature.State(
+      connection: connection,
+      selectedProfileName: "work",
+      profilesSupported: true
+    )
+    home.archived = ArchivedSessionsFeature.State(
+      connection: connection,
+      profileName: "work",
+      sessions: [archivedSession]
+    )
+    let store = TestStore(
+      initialState: AppFeature.State(home: home)
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.hermesREST.setUnread = { _, id, _, profile in
+        writes.withValue { $0.append((id, profile)) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.home(.archived(.presented(.delegate(.openSession(archivedSession))))))
+    await store.receive(\.home.delegate.openSession)
+    await store.finish()
+    #expect(store.state.home?.archived == nil)
+    #expect(store.state.liveChat?.storedSessionID == "archived")
+    #expect(store.state.liveChat?.profileName == "work")
+    #expect(writes.value.first?.0 == "archived")
+    #expect(writes.value.first?.1 == "work")
+  }
+
+  @Test func loadedRowPushAcknowledgesSharedReadState() async {
+    let writes = LockIsolated<[(String, String?)]>([])
+    let push = PushClient.inMemory()
+    let store = TestStore(
+      initialState: AppFeature.State(
+        home: SessionListFeature.State(
+          connection: connection,
+          sessions: [Session(id: "pushed", unread: true)],
+          selectedProfileName: "work",
+          profilesSupported: true
+        )
+      )
+    ) {
+      AppFeature()
+    } withDependencies: {
+      $0.push = push.client
+      $0.hermesREST.setUnread = { _, id, _, profile in
+        writes.withValue { $0.append((id, profile)) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.pushTapped(PushTap(sessionID: "pushed")))
+    await store.receive(\.home.delegate.openSession)
+    await store.finish()
+    #expect(store.state.home?.sessions[id: "pushed"]?.unread == false)
+    #expect(writes.value.first?.0 == "pushed")
+    #expect(writes.value.first?.1 == "work")
+  }
 
   /// A push tap routes through the SAME `openSession` delegate path a list tap uses, opening
   /// (resuming) the tapped session. A loaded `Session` is reused (so its title carries over);
@@ -2721,10 +2823,14 @@ struct AppFeatureTests {
   /// placeholder `Session(id:)` fallback.
   @Test func coldLaunchTapStashedThenReplayedOnAutoConnect() async {
     let push = PushClient.inMemory()
+    let writes = LockIsolated<[(String, String?)]>([])
     let store = TestStore(initialState: AppFeature.State(autoConnecting: true)) {
       AppFeature()
     } withDependencies: {
       $0.push = push.client
+      $0.hermesREST.setUnread = { _, id, _, profile in
+        writes.withValue { $0.append((id, profile)) }
+      }
     }
     store.exhaustivity = .off
 
@@ -2747,6 +2853,9 @@ struct AppFeatureTests {
     // The placeholder `Session(id:)` fallback resumed the never-seen session.
     #expect(store.state.liveChat?.storedSessionID == "20260724_cron")
     #expect(store.state.path.last?.sessionKey == "20260724_cron")
+    #expect(writes.value.count == 1)
+    #expect(writes.value.first?.0 == "20260724_cron")
+    #expect(writes.value.first?.1 == nil)
     // A NON-approval tap must never touch the approval badge — neither on the stash
     // branch nor on the replay.
     #expect(store.state.pendingApprovalSessionIDs.isEmpty)

--- a/HermesKit/Tests/HermesKitTests/HermesRESTClientTests.swift
+++ b/HermesKit/Tests/HermesKitTests/HermesRESTClientTests.swift
@@ -185,7 +185,7 @@ struct HermesRESTClientTests {
 
   @Test func sessionsMapsListToDomain() async throws {
     MockURLProtocol.set(json: #"""
-    {"sessions":[{"id":"20260610_120231_afcca6","title":"My chat","preview":"hello there","last_active":1749556800.0,"started_at":1749550000.0,"message_count":4,"cwd":"/Users/me/dev/hermes-mobile","is_active":true,"archived":false}],"total":1,"limit":20,"offset":0}
+    {"sessions":[{"id":"20260610_120231_afcca6","title":"My chat","preview":"hello there","last_active":1749556800.0,"started_at":1749550000.0,"message_count":4,"unread":true,"cwd":"/Users/me/dev/hermes-mobile","is_active":true,"archived":false}],"total":1,"limit":20,"offset":0}
     """#)
     let sessions = try await makeClient().sessions(connection, 20, 0, .recent)
     #expect(sessions.count == 1)
@@ -196,6 +196,7 @@ struct HermesRESTClientTests {
     #expect(s.updatedAt == Date(timeIntervalSince1970: 1749556800.0))
     #expect(s.cwd == "/Users/me/dev/hermes-mobile")
     #expect(s.startedAt == Date(timeIntervalSince1970: 1749550000.0))
+    #expect(s.unread == true)
   }
 
   @Test func sessionsDecodesCronSource() async throws {
@@ -398,6 +399,31 @@ struct HermesRESTClientTests {
     } ?? Data()
     let json = try JSONSerialization.jsonObject(with: body) as? [String: Bool]
     #expect(json == ["archived": true])
+  }
+
+  @Test func setUnreadSendsSharedReadStatePatchWithProfileScope() async throws {
+    MockURLProtocol.set(status: 200)
+    try await makeClient().setUnread(connection, "sid", false, "work")
+    let req = try #require(MockURLProtocol.lastRequest)
+    #expect(req.httpMethod == "PATCH")
+    #expect(req.url?.path == "/api/sessions/sid")
+    #expect(req.url?.query == "profile=work")
+    let body = req.httpBody ?? req.httpBodyStream.map { stream -> Data in
+      stream.open()
+      defer { stream.close() }
+      var data = Data()
+      let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: 1024)
+      defer { buffer.deallocate() }
+      while stream.hasBytesAvailable {
+        let read = stream.read(buffer, maxLength: 1024)
+        if read <= 0 { break }
+        data.append(buffer, count: read)
+      }
+      return data
+    } ?? Data()
+    let json = try #require(JSONSerialization.jsonObject(with: body) as? [String: Any])
+    #expect(json["unread"] as? Bool == false)
+    #expect(json["profile"] as? String == "work")
   }
 
   @Test func renameSendsPatchWithTitleBodyAndAuthHeader() async throws {

--- a/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
+++ b/HermesKit/Tests/HermesKitTests/SessionListFeatureTests.swift
@@ -361,19 +361,18 @@ struct SessionListFeatureTests {
 
   // MARK: Unread + pagination
 
-  @Test func unreadReflectsMessageCountAboveSeen() {
-    var state = SessionListFeature.State(
+  @Test func serverUnreadOverridesLegacyDeviceWatermark() {
+    let state = SessionListFeature.State(
       connection: connection,
       sessions: [
-        Session(id: "a", messageCount: 5),  // seen 5 → read
-        Session(id: "b", messageCount: 8),  // seen 5 → unread
-        Session(id: "c", messageCount: 2),  // no seen entry → not unread (unseeded)
+        Session(id: "server-unread", messageCount: 5, unread: true),   // equal local count, server wins
+        Session(id: "server-read", messageCount: 8, unread: false),   // local gap, server wins
+        Session(id: "legacy-unread", messageCount: 8),                // old agent fallback
+        Session(id: "legacy-unseeded", messageCount: 2),
       ],
-      seenCounts: ["a": 5, "b": 5]
+      seenCounts: ["server-unread": 5, "server-read": 5, "legacy-unread": 5]
     )
-    #expect(state.unreadSessionIDs == ["b"])
-    state.seenCounts["b"] = 8
-    #expect(state.unreadSessionIDs.isEmpty)
+    #expect(state.unreadSessionIDs == ["server-unread", "legacy-unread"])
   }
 
   // MARK: Pinning

--- a/docs/features/session-list.md
+++ b/docs/features/session-list.md
@@ -38,12 +38,29 @@ Pause / Resume → `cronActionInFlightIDs` double-fire guard; success refetches 
 trigger, jobs-only for pause/resume; **no optimistic job-state mutation**). Tap = single-open
 inline peek (`expandedCronJobID`) of the newest `cronPeekLimit` runs via the standard `row(_:)`;
 runs matching no fetched job render flat below (`unmatchedCronSessions` — never hide output).
-The header carries the aggregate `cronUnreadCount` badge; cron sessions ride the same
-`seenCounts` unread pipeline as interactive rows. **Capability-gated**: a 404 flips
+The header carries the aggregate `cronUnreadCount` badge; cron sessions use the same shared
+server-backed unread state as interactive rows (with the legacy device-local `seenCounts`
+fallback below). **Capability-gated**: a 404 flips
 `cronJobsSupported` off → flat run list, fetch skipped thereafter; transient failures keep the
 previous jobs (no flapping). Jobs are fetched with the LITERAL selected profile name when
 `profilesSupported` (matching the scoped session list, so a job's runs are actually present),
 unscoped otherwise.
+
+## Shared unread state
+
+On agents that return the optional `unread` field, the backend owns read state: its
+`last_read_at` watermark is shared with Desktop, so opening a row on either client clears the
+other client's dot on its next poll, and later server activity raises it everywhere. Mobile
+PATCHes `{"unread": false}` on **every** open—even when the row already says false—because false
+also represents an untracked legacy row (`last_read_at == NULL`); the first acknowledgement is
+what makes later activity observable. A completion received while the chat remains visible
+acknowledges again after the new activity, so the reply being watched is not rediscovered as
+unread on Desktop. The write is optimistic and best-effort: a failed PATCH is reconciled by the
+next authoritative list poll.
+
+Older agents omit `unread`. For those rows only, mobile preserves its existing device-local
+`seenCounts` behavior (`message_count > last seen`), including first-sight seeding. This is a
+per-row fallback—not a server-wide capability latch—so mixed/transitional responses stay safe.
 
 ## Branch nesting is display-only (#34)
 


### PR DESCRIPTION
Closes #103.

## Summary
- prefer the gateway-backed `unread` field so mobile and Desktop render the same read state
- acknowledge sessions through the shared app-level open path, including archived and push opens
- retain the active chat’s originating profile/capability so visible turn completion updates the correct profile after sidebar switches
- keep the device-local message-count watermark as a compatibility fallback for older agents

## Verification
- iOS Simulator build (Xcode 26.3)
- HermesKit test suite
- fork CI: https://github.com/netera-michael/hermes-mobile/actions/runs/34053806186